### PR TITLE
nick: Fix coil dependency

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -19,12 +19,9 @@ object Dependencies {
         const val systemUiController = "com.google.accompanist:accompanist-systemuicontroller:${Versions.Dependencies.SystemUiController.core}"
     }
 
-    object Coil {
-        const val core = "io.coil-kt:coil:${Versions.Dependencies.Coil.core}"
-    }
-
     object Compose {
         const val activity = "androidx.activity:activity-compose:${Versions.Dependencies.Compose.activity}"
+        const val coil = "io.coil-kt:coil-compose:${Versions.Dependencies.Compose.coil}"
         const val foundation = "androidx.compose.foundation:foundation:${Versions.Dependencies.Compose.core}"
         const val material = "androidx.compose.material:material:${Versions.Dependencies.Compose.core}"
         const val materialDesignIconsCore = "androidx.compose.material:material-icons-core:${Versions.Dependencies.Compose.core}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -21,10 +21,9 @@ object Versions {
             const val core = "4.3.1"
         }
 
-        object Coil { const val core = "2.2.2" }
-
         object Compose {
             const val activity = "1.5.1"
+            const val coil = "1.3.2"
             const val core = "1.2.1"
             const val navigation = "2.5.3"
             const val viewModel = "1.5.1"


### PR DESCRIPTION
### Trello
https://trello.com/c/xgehAc2C/135-fix-coil-dependency

### Issues
- The coil dependency in our project is currently wrong, and points to the wrong library.

This: `io.coil-kt:coil:`

Should really be: `io.coil-kt:coil-compose:`

Since we want to use the coil compose library to load images.

### Proposed Changes
- Update library support.The new coil version should also update from 2.2.2 to 1.3.2

### TO-DO
- Use coil library to load images 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A