### PR TITLE
nick: Create a firebase method that will get a key from a user account.

### DIFF
--- a/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfo.kt
+++ b/firebase/read/src/main/java/com/nicholas/rutherford/track/my/shot/firebase/read/ReadFirebaseUserInfo.kt
@@ -8,6 +8,7 @@ interface ReadFirebaseUserInfo {
     fun getLoggedInAccountEmail(): Flow<String?>
     fun getAccountInfoFlowByEmail(email: String): Flow<AccountInfoRealtimeResponse?>
     fun getAccountInfoListFlow(): Flow<List<AccountInfoRealtimeResponse>?>
+    fun getAccountInfoKeyFlowByEmail(email: String): Flow<String?>
     fun getLastUpdatedDateFlow(): Flow<Date?>
     fun isEmailVerifiedFlow(): Flow<Boolean>
     fun isLoggedInFlow(): Flow<Boolean>


### PR DESCRIPTION
### Trello
https://trello.com/c/y71wlYiv/139-create-a-firebase-method-that-will-get-a-key-from-a-user-account

### Issues
- We currently don't have a way to just get a logged in user accountInfo key in firebase. This account Key, would be what we allocate to identify unique info to the user.

### Proposed Changes
- Create a method to return just the key back of a logged in user. There also could be additions to current firebase functions out there that could additionally return back a key if needed.

### TO-DO
- Use this in order to have the active user table have the account info key when we create / or login to an new or existing account. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 