### PR TITLE
Add a bulk login class that will clear out the database whenever the user logs out of their given account

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -193,12 +193,9 @@ class AppModule {
         viewModel {
             LoginViewModel(
                 application = androidApplication(),
-                existingUserFirebase = get(),
                 navigation = get(),
                 buildType = get(),
-                accountAuthManager = get(),
-                readFirebaseUserInfo = get(),
-                activeUserRepository = get()
+                accountAuthManager = get()
             )
         }
         viewModel {

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
@@ -214,9 +214,7 @@ fun NavigationComponent(
                             )
                         },
                         onLoginButtonClicked = {
-                            coroutineScope.launch {
-                                loginViewModel.onLoginButtonClicked()
-                            }
+                            loginViewModel.onLoginButtonClicked()
                         },
                         onForgotPasswordClicked = { loginViewModel.onForgotPasswordClicked() },
                         onCreateAccountClicked = { loginViewModel.onCreateAccountClicked() },

--- a/feature/login/src/main/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModel.kt
@@ -3,28 +3,19 @@ package com.nicholas.rutherford.track.your.shot.feature.login
 import android.app.Application
 import androidx.lifecycle.ViewModel
 import com.nicholas.rutherford.track.your.shot.build.type.BuildType
-import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
-import com.nicholas.rutherford.track.your.shot.data.room.response.ActiveUser
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.AlertConfirmAndDismissButton
 import com.nicholas.rutherford.track.your.shot.feature.splash.DrawablesIds
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
-import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
-import com.nicholas.rutherford.track.your.shot.firebase.util.existinguser.ExistingUserFirebase
 import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
-import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 
 class LoginViewModel(
     private val application: Application,
-    private val existingUserFirebase: ExistingUserFirebase,
     private val navigation: LoginNavigation,
     private val buildType: BuildType,
-    private val accountAuthManager: AccountAuthManager,
-    private val readFirebaseUserInfo: ReadFirebaseUserInfo,
-    private val activeUserRepository: ActiveUserRepository
+    private val accountAuthManager: AccountAuthManager
 ) : ViewModel() {
 
     internal val loginMutableStateFlow = MutableStateFlow(LoginState())
@@ -56,7 +47,7 @@ class LoginViewModel(
         return null
     }
 
-    suspend fun onLoginButtonClicked() {
+    fun onLoginButtonClicked() {
         val email = loginStateFlow.value.email
         val password = loginStateFlow.value.password
 
@@ -67,7 +58,7 @@ class LoginViewModel(
         }
     }
 
-    internal suspend fun attemptToLoginToAccount(email: String?, password: String?) {
+    internal fun attemptToLoginToAccount(email: String?, password: String?) {
         val emptyString = application.getString(StringsIds.empty)
         val newEmail = email?.filterNot { it.isWhitespace() } ?: emptyString
         val newPassword = password?.filterNot { it.isWhitespace() } ?: emptyString
@@ -79,49 +70,6 @@ class LoginViewModel(
             email = newEmail,
             password = newPassword
         )
-
-//        navigation.enableProgress(progress = Progress())
-//
-//        existingUserFirebase.loginFlow(
-//            email = newEmail,
-//            password = newPassword
-//        )
-//            .collectLatest { isSuccessful ->
-//                if (isSuccessful) {
-//                    onEmailValueChanged(newEmail = application.getString(StringsIds.empty))
-//                    onPasswordValueChanged(newPassword = application.getString(StringsIds.empty))
-//                    readFirebaseUserInfo.getAccountInfoFlowByEmail(email = newEmail)
-//                        .collectLatest { accountInfoRealtimeResponse ->
-//                            accountInfoRealtimeResponse?.let { accountInfo ->
-//                                updateActiveUserFromLoggedInUser(email = accountInfo.email, username = accountInfo.userName)
-//                            } ?: disableProgressAndShowUnableToLoginAlert()
-//                        }
-//                } else {
-//                    disableProgressAndShowUnableToLoginAlert()
-//                }
-//            }
-    }
-
-    internal suspend fun updateActiveUserFromLoggedInUser(email: String, username: String) {
-        readFirebaseUserInfo.getAccountInfoKeyFlowByEmail(email).collectLatest { key ->
-            key?.let { firebaseAccountInfoKey ->
-                if (activeUserRepository.fetchActiveUser() == null) {
-                    activeUserRepository.createActiveUser(
-                        activeUser = ActiveUser(
-                            id = Constants.ACTIVE_USER_ID,
-                            accountHasBeenCreated = true,
-                            username = username,
-                            email = email,
-                            firebaseAccountInfoKey = firebaseAccountInfoKey
-                        )
-                    )
-                    navigation.disableProgress()
-                    navigation.navigateToPlayersList()
-                } else {
-                    disableProgressAndShowUnableToLoginAlert()
-                }
-            } ?: disableProgressAndShowUnableToLoginAlert()
-        }
     }
 
     fun onForgotPasswordClicked() = navigation.navigateToForgotPassword()
@@ -153,21 +101,6 @@ class LoginViewModel(
                 buttonText = application.getString(StringsIds.gotIt)
             ),
             description = application.getString(StringsIds.passwordIsRequiredPleaseEnterAPasswordToLoginToExistingAccount)
-        )
-    }
-
-    internal fun disableProgressAndShowUnableToLoginAlert() {
-        navigation.disableProgress()
-        navigation.alert(alert = unableToLoginToAccountAlert())
-    }
-
-    internal fun unableToLoginToAccountAlert(): Alert {
-        return Alert(
-            title = application.getString(StringsIds.unableToLoginToAccount),
-            dismissButton = AlertConfirmAndDismissButton(
-                buttonText = application.getString(StringsIds.gotIt)
-            ),
-            description = application.getString(StringsIds.havingTroubleLoggingIntoYourAccountPleaseTryAgainAndEnsureCredentialsExistAndAreValid)
         )
     }
 }

--- a/feature/login/src/test/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModelTest.kt
+++ b/feature/login/src/test/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModelTest.kt
@@ -187,6 +187,20 @@ class LoginViewModelTest {
         }
     }
 
+    @Test fun `attempt to login to account should call login function`() {
+        viewModel.attemptToLoginToAccount(email = emailTest, password = passwordTest)
+
+        Assertions.assertEquals(
+            LoginState(
+                launcherDrawableId = DrawablesIds.launcherRoundTest,
+                email = "",
+                password = ""
+            ),
+            viewModel.loginMutableStateFlow.value
+        )
+        verify { accountAuthManager.login(email = emailTest, password = passwordTest) }
+    }
+
     @Test fun `on forgot password clicked should call navigate to forgot password`() {
         viewModel.onForgotPasswordClicked()
 

--- a/helper/account/build.gradle.kts
+++ b/helper/account/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
 
     testImplementation(Dependencies.Mockk.core)
     testImplementation(project(mapOf("path" to ":data-test:firebase")))
+    testImplementation(project(mapOf("path" to ":data-test:room")))
 
     testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
 }

--- a/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImpl.kt
+++ b/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImpl.kt
@@ -99,38 +99,40 @@ class AccountAuthManagerImpl(
                         firebaseAccountInfoKey = firebaseAccountInfoKey
                     )
                 )
-                readFirebaseUserInfo.getPlayerInfoList(accountKey = firebaseAccountInfoKey)
-                    .collectLatest { playerInfoRealtimeWithKeyResponseList ->
-                        if (playerInfoRealtimeWithKeyResponseList.isNotEmpty()) {
-                            val playerList =
-                                playerInfoRealtimeWithKeyResponseList.map { player ->
-                                    Player(
-                                        firstName = player.playerInfo.firstName,
-                                        lastName = player.playerInfo.lastName,
-                                        position = PlayerPositions.fromValue(player.playerInfo.positionValue),
-                                        imageUrl = player.playerInfo.imageUrl
-                                    )
-                                }
-
-                            playerRepository.createListOfPlayers(playerList = playerList)
-                        }
-                        disableProcessAndNavigateToPlayersList()
-                    }
+                collectPlayerInfoList(firebaseAccountInfoKey = firebaseAccountInfoKey)
             } ?: disableProgressAndShowUnableToLoginAlert(isLoggedIn = true)
         }
     }
 
-    internal fun disableProcessAndNavigateToPlayersList() {
+    internal suspend fun collectPlayerInfoList(firebaseAccountInfoKey: String) {
+        readFirebaseUserInfo.getPlayerInfoList(accountKey = firebaseAccountInfoKey)
+            .collectLatest { playerInfoRealtimeWithKeyResponseList ->
+                if (playerInfoRealtimeWithKeyResponseList.isNotEmpty()) {
+                    val playerList =
+                        playerInfoRealtimeWithKeyResponseList.map { player ->
+                            Player(
+                                firstName = player.playerInfo.firstName,
+                                lastName = player.playerInfo.lastName,
+                                position = PlayerPositions.fromValue(player.playerInfo.positionValue),
+                                imageUrl = player.playerInfo.imageUrl
+                            )
+                        }
+
+                    playerRepository.createListOfPlayers(playerList = playerList)
+                }
+                disableProcessAndNavigateToPlayersList()
+            }
+    }
+
+    private fun disableProcessAndNavigateToPlayersList() {
         navigator.progress(progressAction = null)
         navigator.navigate(navigationAction = NavigationActions.DrawerScreen.playersList())
     }
 
-    internal fun disableProgressAndShowUnableToLoginAlert(isLoggedIn: Boolean = false) {
+    suspend fun disableProgressAndShowUnableToLoginAlert(isLoggedIn: Boolean = false) {
         if (isLoggedIn) {
-            scope.launch {
-                existingUserFirebase.logout()
-                clearOutDatabase()
-            }
+            existingUserFirebase.logout()
+            clearOutDatabase()
         }
         navigator.progress(progressAction = null)
         navigator.alert(alertAction = null)

--- a/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
+++ b/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
@@ -1,9 +1,11 @@
 package com.nicholas.rutherford.track.your.shot.helper.account
 
 import android.app.Application
+import com.nicholas.rutherford.track.your.shot.data.room.entities.toActiveUser
 import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.UserRepository
+import com.nicholas.rutherford.track.your.shot.data.test.room.TestActiveUserEntity
 import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestAccountInfoRealTimeResponse
 import com.nicholas.rutherford.track.your.shot.firebase.util.existinguser.ExistingUserFirebase
@@ -128,8 +130,8 @@ class AccountAuthManagerImplTest {
 
     @Nested
     inner class UpdateActiveUserFromLoggedInUser {
-        val key = "key"
-        val activeUser = TestAC
+        private val key = "key"
+        private val activeUserEntity = TestActiveUserEntity().create()
 
         @Test
         fun `when getAccountInfoKeyFlowByEmail returns null should call disableProgressAndShowUnableToLoginAlert`() = runTest {
@@ -143,9 +145,12 @@ class AccountAuthManagerImplTest {
         @Test
         fun `when getAccountInfoKeyFlowByEmail returns value and fetchActiveUser returns info should call delete active user`() = runTest {
             coEvery { readFirebaseUserInfo.getAccountInfoKeyFlowByEmail(email = accountInfoRealtimeResponse.email) } returns flowOf(value = key)
+            coEvery { activeUserRepository.fetchActiveUser() } returns activeUserEntity.toActiveUser()
 
 
             accountAuthManagerImpl.updateActiveUserFromLoggedInUser(email = accountInfoRealtimeResponse.email, username = accountInfoRealtimeResponse.userName)
+
+            coVerify { activeUserRepository.deleteActiveUser() }
         }
     }
 }

--- a/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
+++ b/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
@@ -154,7 +154,7 @@ class AccountAuthManagerImplTest {
 
             accountAuthManagerImpl.checkForActiveUserAndPlayers()
 
-            coVerify(exactly = 0 ) { activeUserRepository.deleteActiveUser() }
+            coVerify(exactly = 0) { activeUserRepository.deleteActiveUser() }
         }
 
         @Test

--- a/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
+++ b/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
@@ -2,11 +2,14 @@ package com.nicholas.rutherford.track.your.shot.helper.account
 
 import android.app.Application
 import com.nicholas.rutherford.track.your.shot.data.room.entities.toActiveUser
+import com.nicholas.rutherford.track.your.shot.data.room.entities.toPlayer
 import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.UserRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.ActiveUser
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestActiveUserEntity
+import com.nicholas.rutherford.track.your.shot.data.test.room.TestPlayerEntity
+import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestAccountInfoRealTimeResponse
 import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestPlayerInfoRealtimeWithKeyResponse
@@ -20,6 +23,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -105,7 +109,7 @@ class AccountAuthManagerImplTest {
             accountAuthManagerImpl.login(email = accountInfoRealtimeResponse.email, password = password)
 
             verify { navigator.progress(progressAction = any()) }
-            verify { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert() }
+            coVerify { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert() }
         }
 
         @Test
@@ -115,7 +119,7 @@ class AccountAuthManagerImplTest {
             accountAuthManagerImpl.login(email = accountInfoRealtimeResponse.email, password = password)
 
             verify { navigator.progress(progressAction = any()) }
-            verify { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert() }
+            coVerify { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert() }
         }
 
         @Test
@@ -126,7 +130,49 @@ class AccountAuthManagerImplTest {
 
             verify { navigator.progress(progressAction = any()) }
 
-            verify(exactly = 0) { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert() }
+            coVerify(exactly = 0) { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert() }
+        }
+    }
+
+    @Nested
+    inner class CheckForActiveUsersAndPlayers {
+        private val activeUserEntity = TestActiveUserEntity().create().copy()
+        private val playerEntityList = listOf(TestPlayerEntity().create())
+
+        @Test
+        fun `when fetch active user is not null should call delete all active users`() = runTest {
+            coEvery { activeUserRepository.fetchActiveUser() } returns activeUserEntity.toActiveUser()
+
+            accountAuthManagerImpl.checkForActiveUserAndPlayers()
+
+            coVerify { activeUserRepository.deleteActiveUser() }
+        }
+
+        @Test
+        fun `when fetch active user is not null should not call delete all active users`() = runTest {
+            coEvery { activeUserRepository.fetchActiveUser() } returns null
+
+            accountAuthManagerImpl.checkForActiveUserAndPlayers()
+
+            coVerify(exactly = 0 ) { activeUserRepository.deleteActiveUser() }
+        }
+
+        @Test
+        fun `when fetch all players is not empty should call delete all players`() = runTest {
+            coEvery { playerRepository.fetchAllPlayers() } returns playerEntityList.map { it.toPlayer() }
+
+            accountAuthManagerImpl.checkForActiveUserAndPlayers()
+
+            coVerify { playerRepository.deleteAllPlayers() }
+        }
+
+        @Test
+        fun `when fetch all players is empty should not call delete all players`() = runTest {
+            coEvery { playerRepository.fetchAllPlayers() } returns emptyList()
+
+            accountAuthManagerImpl.checkForActiveUserAndPlayers()
+
+            coVerify(exactly = 0) { playerRepository.deleteAllPlayers() }
         }
     }
 
@@ -142,7 +188,7 @@ class AccountAuthManagerImplTest {
 
             accountAuthManagerImpl.updateActiveUserFromLoggedInUser(email = accountInfoRealtimeResponse.email, username = accountInfoRealtimeResponse.userName)
 
-            verify { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert(isLoggedIn = true) }
+            coVerify { accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert(isLoggedIn = true) }
         }
 
         @Test
@@ -215,5 +261,81 @@ class AccountAuthManagerImplTest {
             verify { navigator.progress(progressAction = null) }
             verify { navigator.navigate(navigationAction = any()) }
         }
+    }
+
+    @Nested
+    inner class CollectPlayerInfoList {
+        private val key = "key"
+        @Test
+        fun `when getPlayerInfoList returns empty list should call disableProcessAndNavigateToPlayersList and not createListOfPlayers`() = runTest {
+            coEvery { readFirebaseUserInfo.getPlayerInfoList(accountKey = key) } returns flowOf(emptyList())
+
+            accountAuthManagerImpl.collectPlayerInfoList(firebaseAccountInfoKey = key)
+
+            coVerify(exactly = 0) { playerRepository.createListOfPlayers(playerList = any()) }
+            verify { navigator.progress(progressAction = null) }
+            verify { navigator.navigate(navigationAction = any()) }
+        }
+
+        @Test
+        fun `when getPlayerInfoList returns list of info should call disableProcessAndNavigateToPlayersList and createListOfPlayers`() = runTest {
+            val playerInfoRealtimeWithKeyResponseList = listOf(TestPlayerInfoRealtimeWithKeyResponse().create())
+
+            coEvery { readFirebaseUserInfo.getPlayerInfoList(accountKey = key) } returns flowOf(playerInfoRealtimeWithKeyResponseList)
+
+            accountAuthManagerImpl.collectPlayerInfoList(firebaseAccountInfoKey = key)
+
+            coVerify { playerRepository.createListOfPlayers(playerList = any()) }
+            verify { navigator.progress(progressAction = null) }
+            verify { navigator.navigate(navigationAction = any()) }
+        }
+    }
+
+    @Nested
+    inner class DisableProgressAndShowUnableToLoginAlert {
+
+        @Test
+        fun `when isLoggedIn is set to true should log out and clear database, and call unable to login alert`() = runTest {
+            accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert(isLoggedIn = true)
+
+            verify { existingUserFirebase.logout() }
+            coVerify { accountAuthManagerImpl.clearOutDatabase() }
+
+            verifyOrder {
+                navigator.progress(progressAction = null)
+                navigator.alert(alertAction = any())
+                navigator.alert(alertAction = any())
+            }
+        }
+
+        @Test
+        fun `when isLoggedIn is set to false should not log out and clear database, and call unable to login alert`() = runTest {
+            accountAuthManagerImpl.disableProgressAndShowUnableToLoginAlert(isLoggedIn = false)
+
+            verify(exactly = 0) { existingUserFirebase.logout() }
+            coVerify(exactly = 0) { accountAuthManagerImpl.clearOutDatabase() }
+
+            verifyOrder {
+                navigator.progress(progressAction = null)
+                navigator.alert(alertAction = any())
+                navigator.alert(alertAction = any())
+            }
+        }
+    }
+
+    @Test
+    fun `unableToLoginAccountAlert should have valid values`() {
+        Assertions.assertEquals(
+            accountAuthManagerImpl.unableToLoginToAccountAlert().title,
+            application.getString(StringsIds.unableToLoginToAccount)
+        )
+        Assertions.assertEquals(
+            accountAuthManagerImpl.unableToLoginToAccountAlert().description,
+            application.getString(StringsIds.havingTroubleLoggingIntoYourAccountPleaseTryAgainAndEnsureCredentialsExistAndAreValid)
+        )
+        Assertions.assertEquals(
+            accountAuthManagerImpl.unableToLoginToAccountAlert().dismissButton!!.buttonText,
+            application.getString(StringsIds.gotIt)
+        )
     }
 }

--- a/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
+++ b/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
@@ -5,9 +5,11 @@ import com.nicholas.rutherford.track.your.shot.data.room.entities.toActiveUser
 import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.UserRepository
+import com.nicholas.rutherford.track.your.shot.data.room.response.ActiveUser
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestActiveUserEntity
 import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestAccountInfoRealTimeResponse
+import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestPlayerInfoRealtimeWithKeyResponse
 import com.nicholas.rutherford.track.your.shot.firebase.util.existinguser.ExistingUserFirebase
 import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import com.nicholas.rutherford.track.your.shot.navigation.Navigator
@@ -131,7 +133,8 @@ class AccountAuthManagerImplTest {
     @Nested
     inner class UpdateActiveUserFromLoggedInUser {
         private val key = "key"
-        private val activeUserEntity = TestActiveUserEntity().create()
+        private val activeUserEntity = TestActiveUserEntity().create().copy()
+        private val playerInfoRealtimeWithKeyResponseList = listOf(TestPlayerInfoRealtimeWithKeyResponse().create())
 
         @Test
         fun `when getAccountInfoKeyFlowByEmail returns null should call disableProgressAndShowUnableToLoginAlert`() = runTest {
@@ -144,13 +147,73 @@ class AccountAuthManagerImplTest {
 
         @Test
         fun `when getAccountInfoKeyFlowByEmail returns value and fetchActiveUser returns info should call delete active user`() = runTest {
-            coEvery { readFirebaseUserInfo.getAccountInfoKeyFlowByEmail(email = accountInfoRealtimeResponse.email) } returns flowOf(value = key)
+            coEvery { readFirebaseUserInfo.getAccountInfoKeyFlowByEmail(email = activeUserEntity.email) } returns flowOf(value = key)
             coEvery { activeUserRepository.fetchActiveUser() } returns activeUserEntity.toActiveUser()
 
+            accountAuthManagerImpl.updateActiveUserFromLoggedInUser(email = activeUserEntity.email, username = activeUserEntity.username)
 
-            accountAuthManagerImpl.updateActiveUserFromLoggedInUser(email = accountInfoRealtimeResponse.email, username = accountInfoRealtimeResponse.userName)
-
+            coVerify {
+                activeUserRepository.createActiveUser(
+                    activeUser = ActiveUser(
+                        id = Constants.ACTIVE_USER_ID,
+                        accountHasBeenCreated = true,
+                        username = activeUserEntity.username,
+                        email = activeUserEntity.email,
+                        firebaseAccountInfoKey = key
+                    )
+                )
+            }
             coVerify { activeUserRepository.deleteActiveUser() }
+        }
+
+        @Test
+        fun `when getAccountInfoKeyFlowByEmail returns value, fetchActiveUser returns null, when get playerInfoList returns empty should not call create list of players`() = runTest {
+            coEvery { readFirebaseUserInfo.getAccountInfoKeyFlowByEmail(email = activeUserEntity.email) } returns flowOf(value = key)
+            coEvery { activeUserRepository.fetchActiveUser() } returns null
+            coEvery { readFirebaseUserInfo.getPlayerInfoList(accountKey = key) } returns flowOf(emptyList())
+
+            accountAuthManagerImpl.updateActiveUserFromLoggedInUser(email = activeUserEntity.email, username = activeUserEntity.username)
+
+            coVerify {
+                activeUserRepository.createActiveUser(
+                    activeUser = ActiveUser(
+                        id = Constants.ACTIVE_USER_ID,
+                        accountHasBeenCreated = true,
+                        username = activeUserEntity.username,
+                        email = activeUserEntity.email,
+                        firebaseAccountInfoKey = key
+                    )
+                )
+            }
+            coVerify(exactly = 0) { activeUserRepository.deleteActiveUser() }
+            coVerify(exactly = 0) { playerRepository.createListOfPlayers(playerList = any()) }
+            verify { navigator.progress(progressAction = null) }
+            verify { navigator.navigate(navigationAction = any()) }
+        }
+
+        @Test
+        fun `when getAccountInfoKeyFlowByEmail returns value, fetchActiveUser returns null, when get playerInfoList returns data should call create list of players`() = runTest {
+            coEvery { readFirebaseUserInfo.getAccountInfoKeyFlowByEmail(email = activeUserEntity.email) } returns flowOf(value = key)
+            coEvery { activeUserRepository.fetchActiveUser() } returns null
+            coEvery { readFirebaseUserInfo.getPlayerInfoList(accountKey = key) } returns flowOf(playerInfoRealtimeWithKeyResponseList)
+
+            accountAuthManagerImpl.updateActiveUserFromLoggedInUser(email = activeUserEntity.email, username = activeUserEntity.username)
+
+            coVerify {
+                activeUserRepository.createActiveUser(
+                    activeUser = ActiveUser(
+                        id = Constants.ACTIVE_USER_ID,
+                        accountHasBeenCreated = true,
+                        username = activeUserEntity.username,
+                        email = activeUserEntity.email,
+                        firebaseAccountInfoKey = key
+                    )
+                )
+            }
+            coVerify(exactly = 0) { activeUserRepository.deleteActiveUser() }
+            coVerify { playerRepository.createListOfPlayers(playerList = any()) }
+            verify { navigator.progress(progressAction = null) }
+            verify { navigator.navigate(navigationAction = any()) }
         }
     }
 }


### PR DESCRIPTION
### Trello
https://trello.com/b/UAh3A6Yj/project-track-my-shot

### Issues
- When the user logs out of their given account, we want to clear the database completely. This is because when the user logins; we want new data and not save old account info data.

### Proposed Changes
- Clear out the entire database when we logout.

### TO-DO
= Players list empty state 
- Update players list UI 

### Additional Info
- This is mostly the unit tests since the real code got merged in already which was weird that it did since I had protection rules on it. 

### Screenshots / Videos 
- n/a 