### PR TITLE
nick: Adding isPending field to the ShotLogged data class

### DIFF
--- a/data-test/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/TestShotLoggedRealtimeResponse.kt
+++ b/data-test/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/TestShotLoggedRealtimeResponse.kt
@@ -11,7 +11,8 @@ object TestShotLoggedRealtimeResponse {
             shotsMadePercentValue = SHOTS_MADE_PERCENT_VALUE,
             shotsMissedPercentValue = SHOTS_MISSED_PERCENT_VALUE,
             shotsAttemptedMillisecondsValue = SHOTS_ATTEMPTED_MILLISECONDS_VALUE,
-            shotsLoggedMillisecondsValue = SHOTS_LOGGED_MILLISECONDS_VALUE
+            shotsLoggedMillisecondsValue = SHOTS_LOGGED_MILLISECONDS_VALUE,
+            isPending = IS_PENDING
         )
     }
 
@@ -23,4 +24,5 @@ object TestShotLoggedRealtimeResponse {
     private const val SHOTS_MISSED_PERCENT_VALUE = 66.67
     private const val SHOTS_ATTEMPTED_MILLISECONDS_VALUE = 1000L
     private const val SHOTS_LOGGED_MILLISECONDS_VALUE = 2000L
+    private const val IS_PENDING = false
 }

--- a/data-test/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/test/room/TestShotLogged.kt
+++ b/data-test/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/test/room/TestShotLogged.kt
@@ -13,7 +13,8 @@ object TestShotLogged {
             shotsMadePercentValue = SHOTS_MADE_PERCENT_VALUE,
             shotsMissedPercentValue = SHOTS_MISSED_PERCENT_VALUE,
             shotsAttemptedMillisecondsValue = SHOTS_ATTEMPTED_MILLISECONDS_VALUE,
-            shotsLoggedMillisecondsValue = SHOTS_LOGGED_MILLISECONDS_VALUE
+            shotsLoggedMillisecondsValue = SHOTS_LOGGED_MILLISECONDS_VALUE,
+            isPending = IS_PENDING
         )
     }
 
@@ -25,4 +26,5 @@ object TestShotLogged {
     private const val SHOTS_MISSED_PERCENT_VALUE = 66.67
     private const val SHOTS_ATTEMPTED_MILLISECONDS_VALUE = 1000L
     private const val SHOTS_LOGGED_MILLISECONDS_VALUE = 2000L
+    private const val IS_PENDING = false
 }

--- a/data/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/ShotLoggedRealtimeResponse.kt
+++ b/data/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/ShotLoggedRealtimeResponse.kt
@@ -8,5 +8,6 @@ data class ShotLoggedRealtimeResponse(
     val shotsMadePercentValue: Double = 0.0,
     val shotsMissedPercentValue: Double = 0.0,
     val shotsAttemptedMillisecondsValue: Long = 0L,
-    val shotsLoggedMillisecondsValue: Long = 0L
+    val shotsLoggedMillisecondsValue: Long = 0L,
+    val isPending: Boolean = false
 )

--- a/data/room/schemas/com.nicholas.rutherford.track.your.shot.data.room.database.AppDatabase/5.json
+++ b/data/room/schemas/com.nicholas.rutherford.track.your.shot.data.room.database.AppDatabase/5.json
@@ -1,0 +1,184 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "8cb248f4f5c3213a2ee73ecadb233c9c",
+    "entities": [
+      {
+        "tableName": "activeUsers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `accountHasBeenCreated` INTEGER NOT NULL, `email` TEXT NOT NULL, `username` TEXT NOT NULL, `firebaseAccountInfoKey` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountHasBeenCreated",
+            "columnName": "accountHasBeenCreated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firebaseAccountInfoKey",
+            "columnName": "firebaseAccountInfoKey",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "declaredShots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `shotCategory` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shotCategory",
+            "columnName": "shotCategory",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "players",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `firstName` TEXT NOT NULL, `lastName` TEXT NOT NULL, `position` INTEGER NOT NULL, `firebaseKey` TEXT NOT NULL, `imageUrl` TEXT, `shotsLogged` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firebaseKey",
+            "columnName": "firebaseKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shotsLoggedList",
+            "columnName": "shotsLogged",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `email` TEXT NOT NULL, `username` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8cb248f4f5c3213a2ee73ecadb233c9c')"
+    ]
+  }
+}

--- a/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/database/AppDatabase.kt
+++ b/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/database/AppDatabase.kt
@@ -25,9 +25,10 @@ import com.nicholas.rutherford.track.your.shot.data.room.entities.UserEntity
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
-        AutoMigration(from = 3, to = 4)
+        AutoMigration(from = 3, to = 4),
+        AutoMigration(from = 4, to = 5)
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(PlayerPositionsConverter::class, ShotLoggedConverter::class)

--- a/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/response/ShotLogged.kt
+++ b/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/response/ShotLogged.kt
@@ -18,5 +18,7 @@ data class ShotLogged(
     @ColumnInfo(name = "shotsAttemptedMillisecondsValue")
     val shotsAttemptedMillisecondsValue: Long,
     @ColumnInfo(name = "shotsLoggedMillisecondsValue")
-    val shotsLoggedMillisecondsValue: Long
+    val shotsLoggedMillisecondsValue: Long,
+    @ColumnInfo(name = "isPending")
+    val isPending: Boolean
 )

--- a/firebase/core/src/test/java/com/nicholas/rutherford/track/your/shot/firebase/core/create/CreateFirebaseLastUpdatedImplTest.kt
+++ b/firebase/core/src/test/java/com/nicholas/rutherford/track/your/shot/firebase/core/create/CreateFirebaseLastUpdatedImplTest.kt
@@ -9,7 +9,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
@@ -34,7 +33,6 @@ class CreateFirebaseLastUpdatedImplTest {
     @Nested
     inner class AttemptToCreateAccountFirebaseAuthResponseFlow {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when add on complete listener is executed should set flow to false when isSuccessful returns back false`() = runTest {
             val mockTaskVoidResult = mockk<Task<Void>>()
@@ -58,7 +56,6 @@ class CreateFirebaseLastUpdatedImplTest {
             Assertions.assertEquals(false, value)
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when add on complete listener is executed should set flow to true when isSuccessful returns back true`() = runTest {
             val mockTaskVoidResult = mockk<Task<Void>>()

--- a/firebase/core/src/test/java/com/nicholas/rutherford/track/your/shot/firebase/core/read/ReadFirebaseUserInfoImplTest.kt
+++ b/firebase/core/src/test/java/com/nicholas/rutherford/track/your/shot/firebase/core/read/ReadFirebaseUserInfoImplTest.kt
@@ -19,7 +19,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
@@ -48,7 +47,6 @@ class ReadFirebaseUserInfoImplTest {
     @Nested
     inner class GetLoggedInAccountEmail {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser is set to null should set to null`() = runTest {
             every { firebaseAuth.currentUser } returns null
@@ -57,7 +55,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getLoggedInAccountEmail().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser email is set to null should set to null`() = runTest {
             every { firebaseAuth.currentUser!!.email } returns null
@@ -66,7 +63,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getLoggedInAccountEmail().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser and email is not set to null should set value to returned email`() = runTest {
             every { firebaseAuth.currentUser!!.email } returns accountInfoRealtimeResponse.email
@@ -79,7 +75,6 @@ class ReadFirebaseUserInfoImplTest {
     @Nested
     inner class GetAccountInfoListFlow {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onCancelled is called should return null`() = runTest {
             val mockDatabaseError = mockk<DatabaseError>()
@@ -96,7 +91,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoListFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called with snapshot exists return back as false should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -121,7 +115,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoListFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called with snapshot exists return back as true with snapshot child data should return info`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -150,7 +143,6 @@ class ReadFirebaseUserInfoImplTest {
     @Nested
     inner class GetLastUpdatedDateFlow {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onCancelled is called should return null`() = runTest {
             val mockDatabaseError = mockk<DatabaseError>()
@@ -167,7 +159,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getLastUpdatedDateFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called but snapshot does not exist should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -188,7 +179,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getLastUpdatedDateFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called, snapshot exists, and value returns null should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -210,7 +200,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getLastUpdatedDateFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called, snapshot exists, and value returns date should return valid date`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -236,7 +225,6 @@ class ReadFirebaseUserInfoImplTest {
     @Nested
     inner class GetAccountInfoKeyByEmail {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onCancelled is called should return null`() = runTest {
             val mockDatabaseError = mockk<DatabaseError>()
@@ -255,7 +243,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoKeyFlowByEmail(accountInfoRealtimeResponse.email).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called but snapshot does not exist should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -278,7 +265,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoKeyFlowByEmail(accountInfoRealtimeResponse.email).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called, snapshot exists, and children key returns empty should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -302,7 +288,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoKeyFlowByEmail(accountInfoRealtimeResponse.email).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called, snapshot exists, and children key returns info should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -333,7 +318,6 @@ class ReadFirebaseUserInfoImplTest {
     @Nested
     inner class GetAccountInfoFlowByEmail {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onCancelled is called should return null`() = runTest {
             val mockDatabaseError = mockk<DatabaseError>()
@@ -352,7 +336,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoFlowByEmail(accountInfoRealtimeResponse.email).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called but the count is 0 should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -379,7 +362,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoFlowByEmail(accountInfoRealtimeResponse.email).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called but the count is greater then 1 should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -406,7 +388,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoFlowByEmail(accountInfoRealtimeResponse.email).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called with snapshot exists return back as false should return null`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -433,7 +414,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(null, readFirebaseUserInfoImpl.getAccountInfoFlowByEmail(accountInfoRealtimeResponse.email).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onDataChange is called with valid conditions should return accountInfoRealTimeResponse`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -465,7 +445,6 @@ class ReadFirebaseUserInfoImplTest {
     inner class GetPlayerInfoList {
         private val playerInfoRealtimeWithKeyResponseEmptyList: List<PlayerInfoRealtimeWithKeyResponse> = emptyList()
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when onCancelled is called should return empty list`() = runTest {
             val mockDatabaseError = mockk<DatabaseError>()
@@ -484,7 +463,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(playerInfoRealtimeWithKeyResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when on data change is called but snapshot does not exist should return empty list`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -507,7 +485,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(playerInfoRealtimeWithKeyResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when snapshot exists but children count is zero should return empty list`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -531,7 +508,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(playerInfoRealtimeWithKeyResponseEmptyList, readFirebaseUserInfoImpl.getPlayerInfoList(accountKey = firebaseAccountKey).first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when snapshot exists and has children should return list of player info`() = runTest {
             val mockDataSnapshot = mockk<DataSnapshot>()
@@ -571,7 +547,6 @@ class ReadFirebaseUserInfoImplTest {
     @Nested
     inner class IsEmailVerifiedFlow {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser is set to null should set to false`() = runTest {
             every { firebaseAuth.currentUser } returns null
@@ -580,7 +555,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(false, readFirebaseUserInfoImpl.isEmailVerifiedFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser is not null but complete listener is not successful should be set to false`() = runTest {
             val mockTaskReloadResult = mockk<Task<Void>>()
@@ -598,7 +572,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(false, readFirebaseUserInfoImpl.isEmailVerifiedFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser is not null but complete listener is successful with email verified set to false should be set to false`() = runTest {
             val mockTaskReloadResult = mockk<Task<Void>>()
@@ -617,7 +590,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(false, readFirebaseUserInfoImpl.isEmailVerifiedFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser is not null but complete listener is successful with email verified set to true should be set to true`() = runTest {
             val mockTaskReloadResult = mockk<Task<Void>>()
@@ -640,7 +612,6 @@ class ReadFirebaseUserInfoImplTest {
     @Nested
     inner class IsLoggedInFlow {
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser is set to null should set to false`() = runTest {
             every { firebaseAuth.currentUser } returns null
@@ -649,7 +620,6 @@ class ReadFirebaseUserInfoImplTest {
             Assertions.assertEquals(false, readFirebaseUserInfoImpl.isLoggedInFlow().first())
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         @Test
         fun `when currentUser is not set to null should be set to true`() = runTest {
             readFirebaseUserInfoImpl = ReadFirebaseUserInfoImpl(firebaseAuth = firebaseAuth, firebaseDatabase = firebaseDatabase)

--- a/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImpl.kt
+++ b/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImpl.kt
@@ -154,7 +154,8 @@ class AccountAuthManagerImpl(
                                         shotsMadePercentValue = shotLoggedRealtimeResponse.shotsMadePercentValue,
                                         shotsMissedPercentValue = shotLoggedRealtimeResponse.shotsMissedPercentValue,
                                         shotsAttemptedMillisecondsValue = shotLoggedRealtimeResponse.shotsAttemptedMillisecondsValue,
-                                        shotsLoggedMillisecondsValue = shotLoggedRealtimeResponse.shotsLoggedMillisecondsValue
+                                        shotsLoggedMillisecondsValue = shotLoggedRealtimeResponse.shotsLoggedMillisecondsValue,
+                                        isPending = shotLoggedRealtimeResponse.isPending
                                     )
                                 }
                             )

--- a/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
+++ b/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountAuthManagerImplTest.kt
@@ -327,7 +327,8 @@ class AccountAuthManagerImplTest {
                                 shotsMadePercentValue = shotLoggedRealtimeResponse.shotsMadePercentValue,
                                 shotsMissedPercentValue = shotLoggedRealtimeResponse.shotsMissedPercentValue,
                                 shotsAttemptedMillisecondsValue = shotLoggedRealtimeResponse.shotsAttemptedMillisecondsValue,
-                                shotsLoggedMillisecondsValue = shotLoggedRealtimeResponse.shotsLoggedMillisecondsValue
+                                shotsLoggedMillisecondsValue = shotLoggedRealtimeResponse.shotsLoggedMillisecondsValue,
+                                isPending = shotLoggedRealtimeResponse.isPending
                             )
                         }
                     )


### PR DESCRIPTION
### Trello
- https://trello.com/c/OO2GbP1L/177-adding-ispending-field-to-the-shotlogged-data-class

### Issues
- We want the ability that when a shot is logged to attach isPending field so that way we can know if a shot is pending or not. This will be used to trigger pending shot ideas when we go to create them.

### Proposed Changes
- Introduce a new `isPending` field to ShotsLogged that way we can validate if the current shot were looking to law is pending or not.

### TO-DO
- Use the new field, when we add a new shot to determine if the shot should be pending or not. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 