### PR TITLE
nick: Create a function that deletes isPending shots for all players

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -60,8 +60,8 @@ import com.nicholas.rutherford.track.your.shot.firebase.util.authentication.Auth
 import com.nicholas.rutherford.track.your.shot.firebase.util.authentication.AuthenticationFirebaseImpl
 import com.nicholas.rutherford.track.your.shot.firebase.util.existinguser.ExistingUserFirebase
 import com.nicholas.rutherford.track.your.shot.firebase.util.existinguser.ExistingUserFirebaseImpl
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManagerImpl
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManagerImpl
 import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import com.nicholas.rutherford.track.your.shot.helper.network.Network
 import com.nicholas.rutherford.track.your.shot.helper.network.NetworkImpl
@@ -178,8 +178,8 @@ class AppModule {
         single<Navigator> {
             NavigatorImpl()
         }
-        single<AccountAuthManager> {
-            AccountAuthManagerImpl(
+        single<AccountManager> {
+            AccountManagerImpl(
                 scope = defaultCoroutineScope,
                 application = get(),
                 navigator = get(),
@@ -220,14 +220,14 @@ class AppModule {
             SelectShotNavigationImpl(navigator = get())
         }
         viewModel {
-            MainActivityViewModel(appCenter = get(), accountAuthManager = get())
+            MainActivityViewModel(appCenter = get(), accountManager = get())
         }
         viewModel {
             SplashViewModel(
                 navigation = get(),
                 readFirebaseUserInfo = get(),
                 activeUserRepository = get(),
-                accountAuthManager = get(),
+                accountManager = get(),
                 readSharedPreferences = get(),
                 createSharedPreferences = get()
             )
@@ -237,7 +237,7 @@ class AppModule {
                 application = androidApplication(),
                 navigation = get(),
                 buildType = get(),
-                accountAuthManager = get()
+                accountManager = get()
             )
         }
         viewModel {
@@ -246,7 +246,7 @@ class AppModule {
                 scope = defaultCoroutineScope,
                 navigation = get(),
                 network = get(),
-                accountAuthManager = get(),
+                accountManager = get(),
                 deleteFirebaseUserInfo = get(),
                 activeUserRepository = get(),
                 playersAdditionUpdates = get(),
@@ -274,7 +274,7 @@ class AppModule {
                 scope = defaultCoroutineScope,
                 navigation = get(),
                 declaredShotRepository = get(),
-                accountAuthManager = get(),
+                accountManager = get(),
                 createSharedPreferences = get(),
                 readSharedPreferences = get()
             )

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/MainActivityViewModel.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/MainActivityViewModel.kt
@@ -3,18 +3,18 @@ package com.nicholas.rutherford.track.your.shot
 import androidx.lifecycle.ViewModel
 import com.nicholas.rutherford.track.your.shot.app.center.AppCenter
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 
 class MainActivityViewModel(
     private val appCenter: AppCenter,
-    private val accountAuthManager: AccountAuthManager
+    private val accountManager: AccountManager
 ) : ViewModel() {
 
     fun initAppCenter() = appCenter.start()
 
     fun logout(titleId: Int) {
         if (titleId == StringsIds.logout) {
-            accountAuthManager.logout()
+            accountManager.logout()
         }
     }
 }

--- a/feature/login/src/main/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModel.kt
@@ -7,7 +7,7 @@ import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.AlertConfirmAndDismissButton
 import com.nicholas.rutherford.track.your.shot.feature.splash.DrawablesIds
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
@@ -15,7 +15,7 @@ class LoginViewModel(
     private val application: Application,
     private val navigation: LoginNavigation,
     private val buildType: BuildType,
-    private val accountAuthManager: AccountAuthManager
+    private val accountManager: AccountManager
 ) : ViewModel() {
 
     internal val loginMutableStateFlow = MutableStateFlow(LoginState())
@@ -66,7 +66,7 @@ class LoginViewModel(
         onEmailValueChanged(newEmail = application.getString(StringsIds.empty))
         onPasswordValueChanged(newPassword = application.getString(StringsIds.empty))
 
-        accountAuthManager.login(
+        accountManager.login(
             email = newEmail,
             password = newPassword
         )

--- a/feature/login/src/test/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModelTest.kt
+++ b/feature/login/src/test/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModelTest.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.nicholas.rutherford.track.your.shot.build.type.BuildTypeImpl
 import com.nicholas.rutherford.track.your.shot.feature.splash.DrawablesIds
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
@@ -20,7 +20,7 @@ class LoginViewModelTest {
     private var navigation = mockk<LoginNavigation>(relaxed = true)
     private var application = mockk<Application>(relaxed = true)
 
-    private var accountAuthManager = mockk<AccountAuthManager>(relaxed = true)
+    private var accountManager = mockk<AccountManager>(relaxed = true)
 
     private val debugVersionName = "debug"
     private val releaseVersionName = "release"
@@ -41,7 +41,7 @@ class LoginViewModelTest {
             application = application,
             navigation = navigation,
             buildType = buildTypeDebug,
-            accountAuthManager = accountAuthManager
+            accountManager = accountManager
         )
     }
 
@@ -59,7 +59,7 @@ class LoginViewModelTest {
                 application = application,
                 navigation = navigation,
                 buildType = buildTypeDebug,
-                accountAuthManager = accountAuthManager
+                accountManager = accountManager
             )
 
             viewModel.updateLauncherDrawableIdState()
@@ -75,7 +75,7 @@ class LoginViewModelTest {
                 application = application,
                 navigation = navigation,
                 buildType = buildTypeStage,
-                accountAuthManager = accountAuthManager
+                accountManager = accountManager
             )
 
             viewModel.updateLauncherDrawableIdState()
@@ -91,7 +91,7 @@ class LoginViewModelTest {
                 application = application,
                 navigation = navigation,
                 buildType = buildTypeRelease,
-                accountAuthManager = accountAuthManager
+                accountManager = accountManager
             )
 
             viewModel.updateLauncherDrawableIdState()
@@ -198,7 +198,7 @@ class LoginViewModelTest {
             ),
             viewModel.loginMutableStateFlow.value
         )
-        verify { accountAuthManager.login(email = emailTest, password = passwordTest) }
+        verify { accountManager.login(email = emailTest, password = passwordTest) }
     }
 
     @Test fun `on forgot password clicked should call navigate to forgot password`() {

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/SelectShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/SelectShotViewModel.kt
@@ -3,7 +3,7 @@ package com.nicholas.rutherford.track.your.shot.feature.players.shots
 import androidx.lifecycle.ViewModel
 import com.nicholas.rutherford.track.your.shot.data.room.repository.DeclaredShotRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
 import kotlinx.coroutines.CoroutineScope
@@ -17,7 +17,7 @@ class SelectShotViewModel(
     private val scope: CoroutineScope,
     private val navigation: SelectShotNavigation,
     private val declaredShotRepository: DeclaredShotRepository,
-    private val accountAuthManager: AccountAuthManager,
+    private val accountManager: AccountManager,
     private val createSharedPreferences: CreateSharedPreferences,
     private val readSharedPreferences: ReadSharedPreferences
 ) : ViewModel() {
@@ -43,7 +43,7 @@ class SelectShotViewModel(
 
     private fun collectLoggedInDeclaredShotsStateFlow() {
         scope.launch {
-            accountAuthManager.loggedInDeclaredShotListStateFlow.collectLatest { declaredShotList ->
+            accountManager.loggedInDeclaredShotListStateFlow.collectLatest { declaredShotList ->
                 if (shouldUpdateStateFromLoggedIn(
                         declaredShotList = declaredShotList,
                         shouldUpdateLoggedInDeclaredShotListState = readSharedPreferences.shouldUpdateLoggedInDeclaredShotListState()

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/SelectShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/SelectShotViewModelTest.kt
@@ -3,7 +3,7 @@ package com.nicholas.rutherford.track.your.shot.feature.players.shots
 import com.nicholas.rutherford.track.your.shot.data.room.repository.DeclaredShotRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestDeclaredShot
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
 import io.mockk.coEvery
@@ -35,7 +35,7 @@ class SelectShotViewModelTest {
 
     private val declaredShotRepository = mockk<DeclaredShotRepository>(relaxed = true)
 
-    private val accountAuthManager = mockk<AccountAuthManager>(relaxed = true)
+    private val accountManager = mockk<AccountManager>(relaxed = true)
 
     private val createSharedPreferences = mockk<CreateSharedPreferences>(relaxed = true)
     private val readSharedPreferences = mockk<ReadSharedPreferences>(relaxed = true)
@@ -46,7 +46,7 @@ class SelectShotViewModelTest {
             scope = scope,
             navigation = navigation,
             declaredShotRepository = declaredShotRepository,
-            accountAuthManager = accountAuthManager,
+            accountManager = accountManager,
             createSharedPreferences = createSharedPreferences,
             readSharedPreferences = readSharedPreferences
         )
@@ -78,13 +78,13 @@ class SelectShotViewModelTest {
             val declaredShotList: List<DeclaredShot> = emptyList()
 
             every { readSharedPreferences.shouldUpdateLoggedInDeclaredShotListState() } returns true
-            every { accountAuthManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
+            every { accountManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
 
             selectShotViewModel = SelectShotViewModel(
                 scope = scope,
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
-                accountAuthManager = accountAuthManager,
+                accountManager = accountManager,
                 createSharedPreferences = createSharedPreferences,
                 readSharedPreferences = readSharedPreferences
             )
@@ -105,13 +105,13 @@ class SelectShotViewModelTest {
             val declaredShotList: List<DeclaredShot> = listOf(TestDeclaredShot.build())
 
             every { readSharedPreferences.shouldUpdateLoggedInDeclaredShotListState() } returns false
-            every { accountAuthManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
+            every { accountManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
 
             selectShotViewModel = SelectShotViewModel(
                 scope = scope,
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
-                accountAuthManager = accountAuthManager,
+                accountManager = accountManager,
                 createSharedPreferences = createSharedPreferences,
                 readSharedPreferences = readSharedPreferences
             )
@@ -131,13 +131,13 @@ class SelectShotViewModelTest {
             val declaredShotList: List<DeclaredShot> = listOf(TestDeclaredShot.build())
 
             every { readSharedPreferences.shouldUpdateLoggedInDeclaredShotListState() } returns true
-            every { accountAuthManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
+            every { accountManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
 
             selectShotViewModel = SelectShotViewModel(
                 scope = scope,
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
-                accountAuthManager = accountAuthManager,
+                accountManager = accountManager,
                 createSharedPreferences = createSharedPreferences,
                 readSharedPreferences = readSharedPreferences
             )

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListViewModel.kt
@@ -12,7 +12,7 @@ import com.nicholas.rutherford.track.your.shot.data.shared.progress.Progress
 import com.nicholas.rutherford.track.your.shot.feature.players.PlayersAdditionUpdates
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.your.shot.firebase.core.delete.DeleteFirebaseUserInfo
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.helper.network.Network
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
@@ -30,7 +30,7 @@ class PlayersListViewModel(
     private val scope: CoroutineScope,
     private val navigation: PlayersListNavigation,
     private val network: Network,
-    private val accountAuthManager: AccountAuthManager,
+    private val accountManager: AccountManager,
     private val deleteFirebaseUserInfo: DeleteFirebaseUserInfo,
     private val activeUserRepository: ActiveUserRepository,
     private val playersAdditionUpdates: PlayersAdditionUpdates,
@@ -76,7 +76,7 @@ class PlayersListViewModel(
 
     private fun collectLoggedInPlayerListStateFlow() {
         scope.launch {
-            accountAuthManager.loggedInPlayerListStateFlow.collectLatest { loggedInPlayerList ->
+            accountManager.loggedInPlayerListStateFlow.collectLatest { loggedInPlayerList ->
                 if (shouldUpdateFromUserLoggedIn(loggedInPlayerList = loggedInPlayerList, shouldUpdateLoggedInPlayerListState = readSharedPreferences.shouldUpdateLoggedInPlayerListState())) {
                     handleLoggedInPlayerList(playerList = loggedInPlayerList)
                     createSharedPreferences.createShouldUpdateLoggedInPlayerListPreference(value = false)

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
@@ -15,7 +15,7 @@ import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.Player
 import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.PlayersListViewModel
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.your.shot.firebase.core.delete.DeleteFirebaseUserInfo
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.helper.network.Network
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
@@ -53,7 +53,7 @@ class PlayersListViewModelTest {
 
     private val network = mockk<Network>(relaxed = true)
 
-    private val accountAuthManager = mockk<AccountAuthManager>(relaxed = true)
+    private val accountManager = mockk<AccountManager>(relaxed = true)
 
     private val deleteFirebaseUserInfo = mockk<DeleteFirebaseUserInfo>(relaxed = true)
     private val activeUserRepository = mockk<ActiveUserRepository>(relaxed = true)
@@ -77,7 +77,7 @@ class PlayersListViewModelTest {
             scope = scope,
             navigation = navigation,
             network = network,
-            accountAuthManager = accountAuthManager,
+            accountManager = accountManager,
             deleteFirebaseUserInfo = deleteFirebaseUserInfo,
             activeUserRepository = activeUserRepository,
             playersAdditionUpdates = playersAdditionUpdates,
@@ -161,7 +161,7 @@ class PlayersListViewModelTest {
         fun `when loggedInPlayerListStateFlow emits a empty list should not update state or list`() = runTest {
             val playerList: List<Player> = emptyList()
 
-            every { accountAuthManager.loggedInPlayerListStateFlow } returns MutableStateFlow(playerList)
+            every { accountManager.loggedInPlayerListStateFlow } returns MutableStateFlow(playerList)
             every { readSharedPreferences.shouldUpdateLoggedInPlayerListState() } returns true
 
             playersListViewModel = PlayersListViewModel(
@@ -169,7 +169,7 @@ class PlayersListViewModelTest {
                 scope = scope,
                 navigation = navigation,
                 network = network,
-                accountAuthManager = accountAuthManager,
+                accountManager = accountManager,
                 deleteFirebaseUserInfo = deleteFirebaseUserInfo,
                 activeUserRepository = activeUserRepository,
                 playersAdditionUpdates = playersAdditionUpdates,
@@ -199,7 +199,7 @@ class PlayersListViewModelTest {
                 shotsLoggedList = emptyList()
             )
 
-            every { accountAuthManager.loggedInPlayerListStateFlow } returns MutableStateFlow(listOf(player))
+            every { accountManager.loggedInPlayerListStateFlow } returns MutableStateFlow(listOf(player))
             every { readSharedPreferences.shouldUpdateLoggedInPlayerListState() } returns false
 
             playersListViewModel = PlayersListViewModel(
@@ -207,7 +207,7 @@ class PlayersListViewModelTest {
                 scope = scope,
                 navigation = navigation,
                 network = network,
-                accountAuthManager = accountAuthManager,
+                accountManager = accountManager,
                 deleteFirebaseUserInfo = deleteFirebaseUserInfo,
                 activeUserRepository = activeUserRepository,
                 playersAdditionUpdates = playersAdditionUpdates,
@@ -238,7 +238,7 @@ class PlayersListViewModelTest {
             )
             val playerList = listOf(player)
 
-            every { accountAuthManager.loggedInPlayerListStateFlow } returns MutableStateFlow(playerList)
+            every { accountManager.loggedInPlayerListStateFlow } returns MutableStateFlow(playerList)
             every { readSharedPreferences.shouldUpdateLoggedInPlayerListState() } returns true
 
             playersListViewModel = PlayersListViewModel(
@@ -246,7 +246,7 @@ class PlayersListViewModelTest {
                 scope = scope,
                 navigation = navigation,
                 network = network,
-                accountAuthManager = accountAuthManager,
+                accountManager = accountManager,
                 deleteFirebaseUserInfo = deleteFirebaseUserInfo,
                 activeUserRepository = activeUserRepository,
                 playersAdditionUpdates = playersAdditionUpdates,

--- a/feature/splash/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/SplashViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
 import kotlinx.coroutines.delay
@@ -18,14 +18,14 @@ class SplashViewModel(
     private val navigation: SplashNavigation,
     private val readFirebaseUserInfo: ReadFirebaseUserInfo,
     private val activeUserRepository: ActiveUserRepository,
-    private val accountAuthManager: AccountAuthManager,
+    private val accountManager: AccountManager,
     private val readSharedPreferences: ReadSharedPreferences,
     private val createSharedPreferences: CreateSharedPreferences
 ) : ViewModel() {
 
     internal fun checkIfAppHasBeenLaunchedBefore() {
         if (!readSharedPreferences.appHasBeenLaunched()) {
-            accountAuthManager.checkIfWeNeedToLogoutOnLaunch()
+            accountManager.checkIfWeNeedToLogoutOnLaunch()
             createSharedPreferences.createAppHasLaunchedPreference(value = true)
         }
     }

--- a/feature/splash/src/test/java/com/nicholas/rutherford/track/your/shot/feature/splash/SplashViewModelTest.kt
+++ b/feature/splash/src/test/java/com/nicholas/rutherford/track/your/shot/feature/splash/SplashViewModelTest.kt
@@ -3,7 +3,7 @@ package com.nicholas.rutherford.track.your.shot.feature.splash
 import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestActiveUser
 import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountAuthManager
+import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
 import io.mockk.coEvery
@@ -33,7 +33,7 @@ class SplashViewModelTest {
     internal var readFirebaseUserInfo = mockk<ReadFirebaseUserInfo>(relaxed = true)
 
     internal var activeUserRepository = mockk<ActiveUserRepository>(relaxed = true)
-    internal val accountAuthManager = mockk<AccountAuthManager>(relaxed = true)
+    internal val accountManager = mockk<AccountManager>(relaxed = true)
 
     internal val readSharedPreferences = mockk<ReadSharedPreferences>(relaxed = true)
     internal val createSharedPreferences = mockk<CreateSharedPreferences>(relaxed = true)
@@ -52,7 +52,7 @@ class SplashViewModelTest {
             navigation = navigation,
             readFirebaseUserInfo = readFirebaseUserInfo,
             activeUserRepository = activeUserRepository,
-            accountAuthManager = accountAuthManager,
+            accountManager = accountManager,
             readSharedPreferences = readSharedPreferences,
             createSharedPreferences = createSharedPreferences
         )
@@ -81,7 +81,7 @@ class SplashViewModelTest {
 
                 viewModel.checkIfAppHasBeenLaunchedBefore()
 
-                verify { accountAuthManager.checkIfWeNeedToLogoutOnLaunch() }
+                verify { accountManager.checkIfWeNeedToLogoutOnLaunch() }
                 verify { createSharedPreferences.createAppHasLaunchedPreference(value = true) }
             }
 
@@ -91,7 +91,7 @@ class SplashViewModelTest {
 
                 viewModel.checkIfAppHasBeenLaunchedBefore()
 
-                verify(exactly = 0) { accountAuthManager.checkIfWeNeedToLogoutOnLaunch() }
+                verify(exactly = 0) { accountManager.checkIfWeNeedToLogoutOnLaunch() }
                 verify(exactly = 0) { createSharedPreferences.createAppHasLaunchedPreference(value = true) }
             }
         }
@@ -115,7 +115,7 @@ class SplashViewModelTest {
                         navigation = navigation,
                         readFirebaseUserInfo = readFirebaseUserInfo,
                         activeUserRepository = activeUserRepository,
-                        accountAuthManager = accountAuthManager,
+                        accountManager = accountManager,
                         readSharedPreferences = readSharedPreferences,
                         createSharedPreferences = createSharedPreferences
                     )
@@ -148,7 +148,7 @@ class SplashViewModelTest {
                         navigation = navigation,
                         readFirebaseUserInfo = readFirebaseUserInfo,
                         activeUserRepository = activeUserRepository,
-                        accountAuthManager = accountAuthManager,
+                        accountManager = accountManager,
                         readSharedPreferences = readSharedPreferences,
                         createSharedPreferences = createSharedPreferences
                     )
@@ -176,7 +176,7 @@ class SplashViewModelTest {
                         navigation = navigation,
                         readFirebaseUserInfo = readFirebaseUserInfo,
                         activeUserRepository = activeUserRepository,
-                        accountAuthManager = accountAuthManager,
+                        accountManager = accountManager,
                         readSharedPreferences = readSharedPreferences,
                         createSharedPreferences = createSharedPreferences
                     )
@@ -208,7 +208,7 @@ class SplashViewModelTest {
                         navigation = navigation,
                         readFirebaseUserInfo = readFirebaseUserInfo,
                         activeUserRepository = activeUserRepository,
-                        accountAuthManager = accountAuthManager,
+                        accountManager = accountManager,
                         readSharedPreferences = readSharedPreferences,
                         createSharedPreferences = createSharedPreferences
                     )
@@ -245,7 +245,7 @@ class SplashViewModelTest {
                         navigation = navigation,
                         readFirebaseUserInfo = readFirebaseUserInfo,
                         activeUserRepository = activeUserRepository,
-                        accountAuthManager = accountAuthManager,
+                        accountManager = accountManager,
                         readSharedPreferences = readSharedPreferences,
                         createSharedPreferences = createSharedPreferences
                     )
@@ -273,7 +273,7 @@ class SplashViewModelTest {
                         navigation = navigation,
                         readFirebaseUserInfo = readFirebaseUserInfo,
                         activeUserRepository = activeUserRepository,
-                        accountAuthManager = accountAuthManager,
+                        accountManager = accountManager,
                         readSharedPreferences = readSharedPreferences,
                         createSharedPreferences = createSharedPreferences
                     )

--- a/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManager.kt
+++ b/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManager.kt
@@ -4,11 +4,12 @@ import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
 import kotlinx.coroutines.flow.StateFlow
 
-interface AccountAuthManager {
+interface AccountManager {
     val loggedInPlayerListStateFlow: StateFlow<List<Player>>
     val loggedInDeclaredShotListStateFlow: StateFlow<List<DeclaredShot>>
 
     fun logout()
     fun checkIfWeNeedToLogoutOnLaunch()
     fun login(email: String, password: String)
+    fun deleteAllPlayersPendingShots()
 }


### PR DESCRIPTION
### Trello
- https://trello.com/c/s5ayfuz0/179-create-a-function-that-deletes-ispending-shots-for-all-players

### Issues
- We need a way to remove a player that has a shot pending associated with it. This should be done incase the user has logged a shot but wants to remove that shot or, if the user clears out the app while the shot is actively being logged; we shouldn’t be saving that pending shot. This function would then be called in two diffrent places:

1. When the user wants to not move forward with there shot logged
2. When the user clears out of the app while adding a player or logging shots that have not been saved.

### Proposed Changes
- Add a function that fetches all players with a given account. Should then loop through all players, and check if there are shots logged. If there are shots logged, filter out all the shots that are pending and delete them on the user account.

### TO-DO
- Use that function on given places where need to update pending shots. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 