### PR TITLE
nick: Update UI view of a pending shot 

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/ScreenContents.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/ScreenContents.kt
@@ -46,9 +46,7 @@ class ScreenContents {
                 permissionNotGrantedForCameraAlert = { createEditPlayerViewModel.permissionNotGrantedForCameraAlert() },
                 permissionNotGrantedForReadMediaOrExternalStorageAlert = { createEditPlayerViewModel.permissionNotGrantedForReadMediaOrExternalStorageAlert() },
                 onSelectedCreateEditImageOption = { option ->
-                    createEditPlayerViewModel.onSelectedCreateEditImageOption(
-                        option
-                    )
+                    createEditPlayerViewModel.onSelectedCreateEditImageOption(option)
                 }
             )
         )

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
@@ -116,11 +116,14 @@ object StringsIds {
     val selectAShot = R.string.select_a_shot
     val selectDate = R.string.select_date
     val settings = R.string.settings
+    val shotNameX = R.string.shot_name_x
     val shotPercentage = R.string.shot_percentage
     val shots = R.string.shots
     val shotsAttempted = R.string.shots_attempted
     val shotsMade = R.string.shots_made
+    val shotsMadeX = R.string.shots_made_x
     val shotsMadePercentage = R.string.shots_made_percentage
+    val shotsMadePercentageX = R.string.shots_made_percentage_x
     val shotsMissedPercentage = R.string.shots_missed_percentage
     val shotsMissed = R.string.shots_missed
     val shotsNotRecordedDescription = R.string.shots_not_recorded_description

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -121,6 +121,9 @@
     <string name="small_forward">Small Forward</string>
     <string name="shooting_guard">Shooting Guard</string>
     <string name="shot_info">Shot Info</string>
+    <string name="shot_name_x">Shot Name - %s \n</string>
+    <string name="shots_made_x">\nShots Made - %s</string>
+    <string name="shots_made_percentage_x">\nShots Made Percentage: %s</string>
     <string name="stats">Stats</string>
     <string name="splash_icon_description">This is a splash image for the splash screen that gets displayed before app is triggered</string>
     <string name="successfully_sent_email_verification">Successfully sent verification</string>

--- a/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/BaseRow.kt
+++ b/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/BaseRow.kt
@@ -42,7 +42,7 @@ fun BaseRow(
     imageVector: ImageVector? = null,
     shouldShowDivider: Boolean = false
 ) {
-    val rowModidifer = onClicked?.let {
+    val rowModifier = onClicked?.let {
         Modifier
             .fillMaxSize()
             .fillMaxWidth()
@@ -55,7 +55,7 @@ fun BaseRow(
             .padding(8.dp)
     }
     Row(
-        modifier = rowModidifer,
+        modifier = rowModifier,
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/data-test/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/TestShotLoggedRealtimeResponse.kt
+++ b/data-test/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/TestShotLoggedRealtimeResponse.kt
@@ -4,6 +4,7 @@ object TestShotLoggedRealtimeResponse {
 
     fun build(): ShotLoggedRealtimeResponse {
         return ShotLoggedRealtimeResponse(
+            shotName = "",
             shotType = SHOT_TYPE,
             shotsAttempted = SHOTS_ATTEMPTED,
             shotsMade = SHOTS_MADE,
@@ -16,6 +17,7 @@ object TestShotLoggedRealtimeResponse {
         )
     }
 
+    private const val SHOT_NAME = "shotName"
     private const val SHOT_TYPE = 3
     private const val SHOTS_ATTEMPTED = 15
     private const val SHOTS_MADE = 5

--- a/data-test/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/TestShotLoggedRealtimeResponse.kt
+++ b/data-test/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/TestShotLoggedRealtimeResponse.kt
@@ -4,7 +4,7 @@ object TestShotLoggedRealtimeResponse {
 
     fun build(): ShotLoggedRealtimeResponse {
         return ShotLoggedRealtimeResponse(
-            shotName = "",
+            shotName = SHOT_NAME,
             shotType = SHOT_TYPE,
             shotsAttempted = SHOTS_ATTEMPTED,
             shotsMade = SHOTS_MADE,

--- a/data-test/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/test/room/TestShotLogged.kt
+++ b/data-test/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/test/room/TestShotLogged.kt
@@ -6,6 +6,7 @@ object TestShotLogged {
 
     fun build(): ShotLogged {
         return ShotLogged(
+            shotName = SHOT_NAME,
             shotType = SHOT_TYPE,
             shotsAttempted = SHOTS_ATTEMPTED,
             shotsMade = SHOTS_MADE,
@@ -18,6 +19,7 @@ object TestShotLogged {
         )
     }
 
+    private const val SHOT_NAME = "shotName"
     private const val SHOT_TYPE = 3
     private const val SHOTS_ATTEMPTED = 15
     private const val SHOTS_MADE = 5

--- a/data/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/ShotLoggedRealtimeResponse.kt
+++ b/data/firebase/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/realtime/ShotLoggedRealtimeResponse.kt
@@ -1,6 +1,7 @@
 package com.nicholas.rutherford.track.your.shot.firebase.realtime
 
 data class ShotLoggedRealtimeResponse(
+    val shotName: String = "",
     val shotType: Int = 0,
     val shotsAttempted: Int = 0,
     val shotsMade: Int = 0,

--- a/data/room/schemas/com.nicholas.rutherford.track.your.shot.data.room.database.AppDatabase/7.json
+++ b/data/room/schemas/com.nicholas.rutherford.track.your.shot.data.room.database.AppDatabase/7.json
@@ -1,0 +1,240 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "ccd2758fda2e383a994a0a6b9e2a8f8a",
+    "entities": [
+      {
+        "tableName": "activeUsers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `accountHasBeenCreated` INTEGER NOT NULL, `email` TEXT NOT NULL, `username` TEXT NOT NULL, `firebaseAccountInfoKey` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountHasBeenCreated",
+            "columnName": "accountHasBeenCreated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firebaseAccountInfoKey",
+            "columnName": "firebaseAccountInfoKey",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "declaredShots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `shotCategory` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shotCategory",
+            "columnName": "shotCategory",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pendingPlayers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `firstName` TEXT NOT NULL, `lastName` TEXT NOT NULL, `position` INTEGER NOT NULL, `firebaseKey` TEXT NOT NULL, `imageUrl` TEXT, `shotsLogged` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firebaseKey",
+            "columnName": "firebaseKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shotsLoggedList",
+            "columnName": "shotsLogged",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "players",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `firstName` TEXT NOT NULL, `lastName` TEXT NOT NULL, `position` INTEGER NOT NULL, `firebaseKey` TEXT NOT NULL, `imageUrl` TEXT, `shotsLogged` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firebaseKey",
+            "columnName": "firebaseKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shotsLoggedList",
+            "columnName": "shotsLogged",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `email` TEXT NOT NULL, `username` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ccd2758fda2e383a994a0a6b9e2a8f8a')"
+    ]
+  }
+}

--- a/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/database/AppDatabase.kt
+++ b/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/database/AppDatabase.kt
@@ -30,9 +30,10 @@ import com.nicholas.rutherford.track.your.shot.data.room.entities.UserEntity
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
-        AutoMigration(from = 5, to = 6)
+        AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 6, to = 7)
     ],
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 @TypeConverters(PlayerPositionsConverter::class, ShotLoggedConverter::class)

--- a/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/response/ShotLogged.kt
+++ b/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/response/ShotLogged.kt
@@ -3,6 +3,8 @@ package com.nicholas.rutherford.track.your.shot.data.room.response
 import androidx.room.ColumnInfo
 
 data class ShotLogged(
+    @ColumnInfo(name = "shotName")
+    val shotName: String,
     @ColumnInfo(name = "shotType")
     val shotType: Int,
     @ColumnInfo(name = "shotsAttempted")

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -142,7 +142,8 @@ class LogShotViewModel(
         return if (percentage == Constants.SHOT_ZERO_VALUE) {
             application.getString(StringsIds.empty)
         } else {
-            val percentageRoundedValue = String.format("%.1f", percentage)
+            val locale = Locale("en", "US")
+            val percentageRoundedValue = String.format(locale, "%.1f", percentage)
             if (percentageRoundedValue.endsWith(".0")) {
                 application.getString(
                     StringsIds.shotPercentage,
@@ -173,7 +174,7 @@ class LogShotViewModel(
         }
     }
 
-    internal fun updateShotsMissedState(shots: Int) {
+    private fun updateShotsMissedState(shots: Int) {
         logShotMutableStateFlow.update { state ->
             state.copy(
                 shotsMissed = shots,
@@ -274,6 +275,7 @@ class LogShotViewModel(
                         shotLogged = PendingShot(
                             player = player,
                             shotLogged = ShotLogged(
+                                shotName = state.shotName,
                                 shotType = currentDeclaredShot?.id ?: 0,
                                 shotsAttempted = state.shotsAttempted,
                                 shotsMade = state.shotsMade,
@@ -287,11 +289,29 @@ class LogShotViewModel(
                             isPendingPlayer = isExistingPlayer
                         )
                     )
+
+                    resetState()
                     navigateToCreateOrEditPlayer()
                 }
             } ?: navigation.alert(alert = invalidLogShotAlert(description = application.getString(StringsIds.playerIsInvalidPleaseTryAgain)))
         }
     }
+
+    private fun resetState() =
+        logShotMutableStateFlow.update { state ->
+            state.copy(
+                shotName = "",
+                playerName = "",
+                playerPosition = 0,
+                shotsLoggedDateValue = "",
+                shotsTakenDateValue = "",
+                shotsMade = 0,
+                shotsMissed = 0,
+                shotsAttempted = 0,
+                shotsMadePercentValue = "",
+                shotsMissedPercentValue = ""
+            )
+        }
 
     fun convertPercentageToDouble(percentage: String): Double {
         if (!percentage.contains("%")) {

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -477,6 +477,7 @@ class LogShotViewModelTest {
             every { application.getString(StringsIds.missedShotsNotRecordedDescription) } returns description
 
             logShotViewModel.logShotMutableStateFlow.value = LogShotState(
+                shotName = "shotName",
                 shotsMade = 5,
                 shotsMissed = 2,
                 shotsAttempted = 4,

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -201,18 +201,6 @@ class CreateEditPlayerViewModel(
         }
     }
 
-    fun shotNameFromType(type: Int): String {
-        var shotName = ""
-
-        scope.launch {
-            shotName = declaredShotRepository.fetchDeclaredShotFromId(id = type)?.title ?: ""
-        }
-
-        println("here is the shot name $shotName")
-
-        return shotName
-    }
-
     internal fun onNavigateToAppSettings() = navigation.appSettings()
 
     fun permissionNotGrantedForCameraAlert() {

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -201,6 +201,18 @@ class CreateEditPlayerViewModel(
         }
     }
 
+    fun shotNameFromType(type: Int): String {
+        var shotName = ""
+
+        scope.launch {
+            shotName = declaredShotRepository.fetchDeclaredShotFromId(id = type)?.title ?: ""
+        }
+
+        println("here is the shot name $shotName")
+
+        return shotName
+    }
+
     internal fun onNavigateToAppSettings() = navigation.appSettings()
 
     fun permissionNotGrantedForCameraAlert() {

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
@@ -2,6 +2,7 @@ package com.nicholas.rutherford.track.your.shot.feature.players.createeditplayer
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,6 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.nicholas.rutherford.track.your.shot.AppColors
 import com.nicholas.rutherford.track.your.shot.base.resources.R
+import com.nicholas.rutherford.track.your.shot.compose.components.BaseRow
 import com.nicholas.rutherford.track.your.shot.data.room.response.ShotLogged
 import com.nicholas.rutherford.track.your.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
@@ -68,21 +70,18 @@ private fun PendingShot(shot: ShotLogged) {
         modifier = Modifier
             .background(AppColors.White)
             .fillMaxWidth()
-            .padding(
-                top = 4.dp,
-                end = 4.dp,
-                bottom = 16.dp
-            ),
+            .padding(top = 4.dp, end = 4.dp),
         elevation = 2.dp
     ) {
         Column {
             Row(
-                modifier = Modifier
-                    .padding(8.dp),
+                modifier = Modifier.padding(8.dp).clickable {
+                                                            //todo -> Add functionality for the user to view or edit a pending shot
+                },
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "Current Pending Shot", // todo update this with real text from shots
+                    text = stringResource(id = StringsIds.shotNameX, shot.shotName),
                     style = TextStyles.body,
                     textAlign = TextAlign.Start,
                     modifier = Modifier.padding(vertical = 4.dp)
@@ -90,12 +89,10 @@ private fun PendingShot(shot: ShotLogged) {
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                IconButton(onClick = { }) {
-                    Icon(
-                        imageVector = Icons.Filled.ArrowForward,
-                        contentDescription = ""
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Filled.ArrowForward,
+                    contentDescription = ""
+                )
             }
         }
     }

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.nicholas.rutherford.track.your.shot.AppColors
 import com.nicholas.rutherford.track.your.shot.base.resources.R
-import com.nicholas.rutherford.track.your.shot.compose.components.BaseRow
 import com.nicholas.rutherford.track.your.shot.data.room.response.ShotLogged
 import com.nicholas.rutherford.track.your.shot.feature.splash.Colors
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
@@ -76,7 +75,7 @@ private fun PendingShot(shot: ShotLogged) {
         Column {
             Row(
                 modifier = Modifier.padding(8.dp).clickable {
-                                                            //todo -> Add functionality for the user to view or edit a pending shot
+                    // todo -> Add functionality for the user to view or edit a pending shot
                 },
                 verticalAlignment = Alignment.CenterVertically
             ) {

--- a/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManagerImpl.kt
+++ b/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManagerImpl.kt
@@ -177,6 +177,7 @@ class AccountManagerImpl(
                                 imageUrl = player.playerInfo.imageUrl,
                                 shotsLoggedList = player.playerInfo.shotsLogged.map { shotLoggedRealtimeResponse ->
                                     ShotLogged(
+                                        shotName = shotLoggedRealtimeResponse.shotName,
                                         shotType = shotLoggedRealtimeResponse.shotType,
                                         shotsAttempted = shotLoggedRealtimeResponse.shotsAttempted,
                                         shotsMade = shotLoggedRealtimeResponse.shotsMade,

--- a/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManagerImplTest.kt
+++ b/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManagerImplTest.kt
@@ -398,6 +398,7 @@ class AccountManagerImplTest {
                         imageUrl = player.playerInfo.imageUrl,
                         shotsLoggedList = player.playerInfo.shotsLogged.map { shotLoggedRealtimeResponse ->
                             ShotLogged(
+                                shotName = shotLoggedRealtimeResponse.shotName,
                                 shotType = shotLoggedRealtimeResponse.shotType,
                                 shotsAttempted = shotLoggedRealtimeResponse.shotsAttempted,
                                 shotsMade = shotLoggedRealtimeResponse.shotsMade,


### PR DESCRIPTION
### Trello
https://trello.com/c/uEdy6Fj6/170-ui-view-of-pending-shot-for-create-player-edit-player-workflow

### Issues
- We currently are displaying pending shots from the UI view if the user was to go from the create or edit player workflow. We need to update UI view of how were displaying that 
- A pending shot doesn't come back with a pending shot name, which is something we want to display for a pending shot. 

### Proposed Changes
- Update UI view 
- Make a new field in Room DB for a shotName that will come back from the pending shot. 

### TO-DO
- Functionality that actually saves a pending shot to a current shot from edit and create player workflow. 
- Ability to go back to a pending shot and edit or view it before you make changes to it. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 