### PR TITLE
nick: Ability to save a pending player from the create / or edit player workflow 

### DIFF
--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -146,7 +146,9 @@ class CreateEditPlayerViewModel(
         createEditPlayerMutableStateFlow.update { state ->
             state.copy(
                 toolbarNameResId = StringsIds.createPlayer,
-                hintLogNewShotText = hintLogNewShotText(firstName = null, lastName = null)
+                hintLogNewShotText = hintLogNewShotText(firstName = null, lastName = null),
+                shots = emptyList(),
+                pendingShots = emptyList()
             )
         }
     }
@@ -155,20 +157,47 @@ class CreateEditPlayerViewModel(
         if (pendingPlayers.size == Constants.PENDING_PLAYERS_EXPECTED_SIZE || pendingShotLoggedList.isNotEmpty()) {
             navigation.alert(alert = unsavedPlayerChangesAlert())
         } else {
+            clearLocalDeclarations()
             clearState()
-            pendingPlayers = emptyList()
-            pendingShotLoggedList = emptyList()
-            editedPlayer = null
             navigation.pop()
         }
     }
 
     internal fun clearState() {
         if (editedPlayer == null) {
-            createEditPlayerMutableStateFlow.value = CreateEditPlayerState()
+            createEditPlayerMutableStateFlow.update { state ->
+                state.copy(
+                    firstName = "",
+                    lastName = "",
+                    editedPlayerUrl = "",
+                    toolbarNameResId = StringsIds.createPlayer,
+                    playerPositionString = "",
+                    hintLogNewShotText = "",
+                    pendingShots = emptyList(),
+                    sheet = null
+                )
+            }
         } else {
-            createEditPlayerMutableStateFlow.value = CreateEditPlayerState().copy(toolbarNameResId = StringsIds.editPlayer)
+            createEditPlayerMutableStateFlow.update { state ->
+                state.copy(
+                    firstName = "",
+                    lastName = "",
+                    editedPlayerUrl = "",
+                    toolbarNameResId = StringsIds.editPlayer,
+                    playerPositionString = "",
+                    hintLogNewShotText = "",
+                    pendingShots = emptyList(),
+                    sheet = null
+                )
+            }
         }
+    }
+
+    internal fun clearLocalDeclarations() {
+        currentPendingShot.clearShotList()
+        pendingPlayers = emptyList()
+        pendingShotLoggedList = emptyList()
+        editedPlayer = null
     }
 
     fun onImageUploadClicked(uri: Uri?) {
@@ -512,11 +541,10 @@ class CreateEditPlayerViewModel(
 
             currentPendingShot.clearShotList()
 
-            navigation.disableProgress()
+            clearLocalDeclarations()
             clearState()
-            pendingPlayers = emptyList()
-            pendingShotLoggedList = emptyList()
-            editedPlayer = null
+
+            navigation.disableProgress()
             navigation.pop()
         } ?: run {
             navigation.disableProgress()

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -1172,18 +1172,18 @@ class CreateEditPlayerViewModelTest {
             Assertions.assertEquals(
                 createEditPlayerViewModel.currentShotLoggedRealtimeResponseList(),
                 listOf(
-                ShotLoggedRealtimeResponse(
-                    shotName = shotLogged.shotName,
-                    shotType = shotLogged.shotType,
-                    shotsAttempted = shotLogged.shotsAttempted,
-                    shotsMade = shotLogged.shotsMade,
-                    shotsMissed = shotLogged.shotsMissed,
-                    shotsMadePercentValue = shotLogged.shotsMadePercentValue,
-                    shotsMissedPercentValue = shotLogged.shotsMissedPercentValue,
-                    shotsAttemptedMillisecondsValue = shotLogged.shotsAttemptedMillisecondsValue,
-                    shotsLoggedMillisecondsValue = shotLogged.shotsLoggedMillisecondsValue,
-                    isPending = false
-                )
+                    ShotLoggedRealtimeResponse(
+                        shotName = shotLogged.shotName,
+                        shotType = shotLogged.shotType,
+                        shotsAttempted = shotLogged.shotsAttempted,
+                        shotsMade = shotLogged.shotsMade,
+                        shotsMissed = shotLogged.shotsMissed,
+                        shotsMadePercentValue = shotLogged.shotsMadePercentValue,
+                        shotsMissedPercentValue = shotLogged.shotsMissedPercentValue,
+                        shotsAttemptedMillisecondsValue = shotLogged.shotsAttemptedMillisecondsValue,
+                        shotsLoggedMillisecondsValue = shotLogged.shotsLoggedMillisecondsValue,
+                        isPending = false
+                    )
                 )
             )
         }

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -501,6 +501,34 @@ class CreateEditPlayerViewModelTest {
     }
 
     @Nested
+    inner class ClearState {
+
+        @Test
+        fun `when editedPlayer is set to null should reset the state flow value`() {
+            createEditPlayerViewModel.clearState()
+
+            Assertions.assertEquals(
+                createEditPlayerViewModel.createEditPlayerStateFlow.value,
+                CreateEditPlayerState()
+            )
+        }
+
+        @Test
+        fun `when editedPlayer is not set to null should reset the state flow value with edit player as toolbar name`() {
+            createEditPlayerViewModel.editedPlayer = TestPlayer().create()
+
+            createEditPlayerViewModel.clearState()
+
+            Assertions.assertEquals(
+                createEditPlayerViewModel.createEditPlayerStateFlow.value,
+                CreateEditPlayerState().copy(
+                    toolbarNameResId = StringsIds.editPlayer
+                )
+            )
+        }
+    }
+
+    @Nested
     inner class OnImageUploadClicked {
 
         @Test
@@ -869,9 +897,35 @@ class CreateEditPlayerViewModelTest {
         }
 
         @Test
-        fun `when all conditions are met should return true`() {
-            val existingPlayer = player
+        fun `when pendingShotLoggedList is not empty should return false`() {
+            createEditPlayerViewModel.pendingShotLoggedList = listOf(
+                PendingShot(
+                    player = TestPlayer().create(),
+                    shotLogged = TestShotLogged.build(),
+                    isPendingPlayer = false
+                )
+            )
 
+            val existingPlayer = player
+            val state = CreateEditPlayerState(
+                firstName = player.firstName,
+                lastName = player.lastName,
+                editedPlayerUrl = player.imageUrl!!,
+                toolbarNameResId = StringsIds.editPlayer,
+                playerPositionString = "Center"
+            )
+
+            Assertions.assertEquals(
+                createEditPlayerViewModel.hasNotEditedExistingPlayer(existingPlayer = existingPlayer, uri = null, state = state),
+                false
+            )
+        }
+
+        @Test
+        fun `when all conditions are met should return true`() {
+            createEditPlayerViewModel.pendingShotLoggedList = emptyList()
+
+            val existingPlayer = player
             val state = CreateEditPlayerState(
                 firstName = player.firstName,
                 lastName = player.lastName,


### PR DESCRIPTION
### Trello
https://trello.com/c/T1193MZQ/182-ability-to-save-a-pending-shot-to-a-active-shot-for-the-create-person-workflow
https://trello.com/c/N020pWqP/183-ability-to-save-a-pending-shot-to-a-active-shot-for-the-edit-person-workflow

### Issues
- We currently didn't have the ability to actually save a player shot entry into Room and Realtime Firebase. It was always saving as an empty list and instead now that we have an instance of a pending shot, we need to convert that to proper `ShotLogged` data class value. 

### Proposed Changes
- For both flows save a pending shot into the Room and Realtime Firebase, so that way that data can get saved when we make updates to the player. 
- Fix some weird issues where state property was updating to fast, causing some flashes between screens. 

### TO-DO
- UI updates to shot info that we should be displaying to the user. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 