### PR TITLE
nick: Bugs - Clearing shot list when editing another field thats not a shot & showing default state when navigating back to previous screen on create or edit player detail screen 

### DIFF
--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -378,7 +378,7 @@ class CreateEditPlayerViewModel(
                     lastName = state.lastName,
                     positionValue = state.playerPositionString.toPlayerPosition(application = application).value,
                     imageUrl = imageUrl ?: "",
-                    shotsLogged = currentShotLoggedRealtimeResponseList(currentShotList = state.shots.map { shots -> shots.toRealtimeResponse() } )
+                    shotsLogged = currentShotLoggedRealtimeResponseList(currentShotList = state.shots.map { shots -> shots.toRealtimeResponse() })
                 )
             ).collectLatest { isSuccessful ->
                 handleFirebaseResponseForSavingPlayer(
@@ -453,7 +453,7 @@ class CreateEditPlayerViewModel(
                                     application = application
                                 ).value,
                                 imageUrl = imageUrl ?: "",
-                                shotsLogged = currentShotLoggedRealtimeResponseList(currentShotList = state.shots.map { shots -> shots.toRealtimeResponse() } )
+                                shotsLogged = currentShotLoggedRealtimeResponseList(currentShotList = state.shots.map { shots -> shots.toRealtimeResponse() })
                             )
                         )
                     ).collectLatest { isSuccessful ->

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -3,7 +3,6 @@ package com.nicholas.rutherford.track.your.shot.players.createeditplayer
 import android.app.Application
 import android.net.Uri
 import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
-import com.nicholas.rutherford.track.your.shot.data.room.repository.DeclaredShotRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
@@ -33,6 +32,7 @@ import com.nicholas.rutherford.track.your.shot.firebase.realtime.PlayerInfoRealt
 import com.nicholas.rutherford.track.your.shot.firebase.realtime.ShotLoggedRealtimeResponse
 import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestPlayerInfoRealtimeResponse
 import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestPlayerInfoRealtimeWithKeyResponse
+import com.nicholas.rutherford.track.your.shot.firebase.realtime.TestShotLoggedRealtimeResponse
 import com.nicholas.rutherford.track.your.shot.helper.network.Network
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -77,7 +77,6 @@ class CreateEditPlayerViewModelTest {
 
     private val playersAdditionUpdates = mockk<PlayersAdditionUpdates>(relaxed = true)
 
-    private val declaredShotRepository = mockk<DeclaredShotRepository>(relaxed = true)
     private val currentPendingShot = mockk<CurrentPendingShot>(relaxed = true)
 
     private val network = mockk<Network>(relaxed = true)
@@ -1140,7 +1139,8 @@ class CreateEditPlayerViewModelTest {
     inner class CurrentShotLoggedRealtimeResponseList {
 
         @Test
-        fun `when pendingShotLoggedList is not empty should return a realtime response`() {
+        fun `when pendingShotLoggedList is not empty should return current passed in list and realtime response`() {
+            val currentShotLoggedList = listOf(TestShotLoggedRealtimeResponse.build())
             val shotLogged = TestShotLogged.build()
 
             createEditPlayerViewModel.pendingShotLoggedList = listOf(
@@ -1152,8 +1152,8 @@ class CreateEditPlayerViewModelTest {
             )
 
             Assertions.assertEquals(
-                createEditPlayerViewModel.currentShotLoggedRealtimeResponseList(),
-                listOf(
+                createEditPlayerViewModel.currentShotLoggedRealtimeResponseList(currentShotList = currentShotLoggedList),
+                currentShotLoggedList + listOf(
                     ShotLoggedRealtimeResponse(
                         id = shotLogged.id,
                         shotName = shotLogged.shotName,
@@ -1172,13 +1172,14 @@ class CreateEditPlayerViewModelTest {
         }
 
         @Test
-        fun `when pendingShotLoggedList is empty should return empty list`() {
-            val emptyList: List<PendingShot> = emptyList()
+        fun `when pendingShotLoggedList is empty should return only current shot logged list`() {
+            val currentShotLoggedList = listOf(TestShotLoggedRealtimeResponse.build())
+
             createEditPlayerViewModel.pendingShotLoggedList = arrayListOf()
 
             Assertions.assertEquals(
-                createEditPlayerViewModel.currentShotLoggedRealtimeResponseList(),
-                emptyList
+                createEditPlayerViewModel.currentShotLoggedRealtimeResponseList(currentShotList = currentShotLoggedList),
+                currentShotLoggedList
             )
         }
     }
@@ -1187,7 +1188,22 @@ class CreateEditPlayerViewModelTest {
     inner class CurrentShotLoggedList {
 
         @Test
-        fun `when pendingShotLoggedList is not empty should return back empty shot`() {
+        fun `when pendingShotLoggedList is not empty should return back current passed in shot list and pending shot`() {
+            val shotLoggedList = listOf(
+                ShotLogged(
+                    id = 4,
+                    shotName = "name",
+                    shotType = 2,
+                    shotsAttempted = 4,
+                    shotsMade = 1,
+                    shotsMissed = 3,
+                    shotsMadePercentValue = 1.0,
+                    shotsMissedPercentValue = 2.0,
+                    shotsAttemptedMillisecondsValue = 1L,
+                    shotsLoggedMillisecondsValue = 2L,
+                    isPending = false
+                )
+            )
             val shotLogged = TestShotLogged.build()
             val pendingShot = PendingShot(
                 player = TestPlayer().create(),
@@ -1198,20 +1214,34 @@ class CreateEditPlayerViewModelTest {
             createEditPlayerViewModel.pendingShotLoggedList = arrayListOf(pendingShot)
 
             Assertions.assertEquals(
-                createEditPlayerViewModel.currentShotLoggedList(),
-                listOf(shotLogged)
+                createEditPlayerViewModel.currentShotLoggedList(currentShotLoggedList = shotLoggedList),
+                shotLoggedList + listOf(shotLogged)
             )
         }
 
         @Test
-        fun `when pendingShotLoggedList is empty should return empty list`() {
-            val emptyShotLoggedList: List<ShotLogged> = emptyList()
+        fun `when pendingShotLoggedList is empty should return only passed in current shot list`() {
+            val shotLoggedList = listOf(
+                ShotLogged(
+                    id = 4,
+                    shotName = "name",
+                    shotType = 2,
+                    shotsAttempted = 4,
+                    shotsMade = 1,
+                    shotsMissed = 3,
+                    shotsMadePercentValue = 1.0,
+                    shotsMissedPercentValue = 2.0,
+                    shotsAttemptedMillisecondsValue = 1L,
+                    shotsLoggedMillisecondsValue = 2L,
+                    isPending = false
+                )
+            )
 
             createEditPlayerViewModel.pendingShotLoggedList = arrayListOf()
 
             Assertions.assertEquals(
-                createEditPlayerViewModel.currentShotLoggedList(),
-                emptyShotLoggedList
+                createEditPlayerViewModel.currentShotLoggedList(currentShotLoggedList = shotLoggedList),
+                shotLoggedList
             )
         }
     }


### PR DESCRIPTION
### Trello
- https://trello.com/c/51nqzjwB/188-bug-if-we-have-a-shot-added-but-edit-another-field-thats-not-the-shot-it-returns-back-a-empty-list-for-all-shots
- https://trello.com/c/pjqan2uh/195-bug-reset-state-shows-when-navigating-back-from-player-detail-to-player-list-should-not-show

### Issues
- Currently if we edit another detail that is not a shot and if we have a current shot for that given player, it will clear that user given show via Firebase and locally via Room, that should not happen. 
- Navigating back to previous screen from create edit player scree, will show the user the first declaration of the ui empty state with no player info, but ins reality it should display that info and then just navigate back to allow the user to confirm that there changes are there. This also happens when user creates or updates player info which makes it seem like the player changes aren't being saved. 

### Proposed Changes
- Include the current shot list as fields we update when the user creates or makes changes to the player state. Currently we were just passing in pending shots but pending shots aren't valid, as the user can have active shots that should come with with any player updates and should ink return override. 
- Introduce a delay before we actually update the state and local declarations, after we pop this stack. This will allow the pop stack to happen first, and then in return update state to happen a half of a second after the fact. This is an instance were the function is completing still fast to clear everything we need to clear. 

### TO-DO
- Functionality and more clean up for app 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A