### PR TITLE
nick: Hide navigation to Stats, Compare Player and Stats, and Voice commands tabs

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
@@ -44,14 +44,11 @@ import com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot.
 import com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot.SelectShotScreen
 import com.nicholas.rutherford.track.your.shot.feature.splash.SplashScreen
 import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
-import com.nicholas.rutherford.track.your.shot.navigation.ComparePlayersStatsAction
 import com.nicholas.rutherford.track.your.shot.navigation.LogoutAction
 import com.nicholas.rutherford.track.your.shot.navigation.NavigationDestinations
 import com.nicholas.rutherford.track.your.shot.navigation.Navigator
 import com.nicholas.rutherford.track.your.shot.navigation.PlayersListAction
 import com.nicholas.rutherford.track.your.shot.navigation.SettingsAction
-import com.nicholas.rutherford.track.your.shot.navigation.StatsAction
-import com.nicholas.rutherford.track.your.shot.navigation.VoiceCommandsAction
 import com.nicholas.rutherford.track.your.shot.navigation.arguments.NamedArguments
 import com.nicholas.rutherford.track.your.shot.navigation.arguments.NavArguments
 import com.nicholas.rutherford.track.your.shot.navigation.asLifecycleAwareState
@@ -229,9 +226,10 @@ fun NavigationComponent(
             DrawerContent(
                 actions = listOf(
                     PlayersListAction,
-                    StatsAction,
-                    ComparePlayersStatsAction,
-                    VoiceCommandsAction,
+                    // todo -> uncomment out when functionality introduced for them
+//                    StatsAction,
+//                    ComparePlayersStatsAction,
+//                    VoiceCommandsAction,
                     SettingsAction,
                     LogoutAction
                 ),


### PR DESCRIPTION
### Trello
https://trello.com/c/8T0ahHvp/190-hide-navigation-to-stats-compare-player-and-stats-and-voice-commands-tabs

### Issues
- We need to hide sheet actions since functionality is not set up for them, and they will not be released with said support for 1st release. 

### Proposed Changes
- Comment them out, with a todo comment to uncomment them out once were ready to add functionality for them. 

### TO-DO
- N/A 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 