### PR TITLE
nick: Ability to edit info of a current log shot in edit player view

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -294,6 +294,8 @@ class AppModule {
                 navigation = get(),
                 declaredShotRepository = get(),
                 accountManager = get(),
+                playerRepository = get(),
+                pendingPlayerRepository = get(),
                 createSharedPreferences = get(),
                 readSharedPreferences = get()
             )

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
@@ -327,8 +327,8 @@ fun NavigationComponent(
                                 playerIdArgument = entry.arguments?.getInt(NamedArguments.PLAYER_ID)
                             )
                         },
-                        onItemClicked = { shotId ->
-                            selectShotViewModel.onDeclaredShotItemClicked(shotId = shotId)
+                        onItemClicked = { shotType ->
+                            selectShotViewModel.onDeclaredShotItemClicked(shotType = shotType)
                         }
                     )
                 )
@@ -347,6 +347,7 @@ fun NavigationComponent(
                                 logShotViewModel.updateIsExistingPlayerAndId(
                                     isExistingPlayerArgument = bundle.getBoolean(NamedArguments.IS_EXISTING_PLAYER),
                                     playerIdArgument = bundle.getInt(NamedArguments.PLAYER_ID),
+                                    shotTypeArgument = bundle.getInt(NamedArguments.SHOT_TYPE),
                                     shotIdArgument = bundle.getInt(NamedArguments.SHOT_ID),
                                     viewCurrentExistingShotArgument = bundle.getBoolean(NamedArguments.VIEW_CURRENT_EXISTING_SHOT),
                                     viewCurrentPendingShotArgument = bundle.getBoolean(NamedArguments.VIEW_CURRENT_PENDING_SHOT)

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/ScreenContents.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/ScreenContents.kt
@@ -48,11 +48,11 @@ class ScreenContents {
                 onSelectedCreateEditImageOption = { option ->
                     createEditPlayerViewModel.onSelectedCreateEditImageOption(option)
                 },
-                onViewShotClicked = { shotId ->
-                    createEditPlayerViewModel.onViewShotClicked(shotId = shotId)
+                onViewShotClicked = { shotType, shotId ->
+                    createEditPlayerViewModel.onViewShotClicked(shotType = shotType, shotId = shotId)
                 },
-                onViewPendingShotClicked = { shotId ->
-                    createEditPlayerViewModel.onViewPendingShotClicked(shotId = shotId)
+                onViewPendingShotClicked = { shotType, shotId ->
+                    createEditPlayerViewModel.onViewPendingShotClicked(shotType = shotType, shotId = shotId)
                 }
             )
         )

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -367,13 +367,19 @@ class LogShotViewModel(
                     if (viewCurrentExistingShot) {
                         // todo -> we need  to check to make sure theres actual changes before we create a pending shot for current shot logged
                         // so in this case, the pendingShot should not equal the shot passed in as a param being the active shot
-                        createPendingShotForCurrentShot(pendingShot = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = shotId)))
+                        createPendingShot(
+                            isACurrentPlayerShot = true,
+                            pendingShot = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = shotId))
+                        )
                     } else if (viewCurrentPendingShot) {
                         // todo -> we need  to check to make sure theres actual changes before we update pending shot
                         // so in this case, the pendingShot should not equal the shot passed in as a param
                         updatePendingShot(pendingShot = pendingShot)
                     } else {
-                        createPendingShot(pendingShot = pendingShot)
+                        createPendingShot(
+                            isACurrentPlayerShot = false,
+                            pendingShot = pendingShot
+                        )
                     }
                 }
             } ?: navigation.alert(alert = invalidLogShotAlert(description = application.getString(StringsIds.playerIsInvalidPleaseTryAgain)))
@@ -403,13 +409,12 @@ class LogShotViewModel(
         navigateToCreateOrEditPlayer()
     }
 
-    private fun createPendingShot(pendingShot: PendingShot) {
-        currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = currentPlayerShotSize + 1)))
-        navigateToCreateOrEditPlayer()
-    }
-
-    private fun createPendingShotForCurrentShot(pendingShot: PendingShot) {
-        currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged))
+    private fun createPendingShot(isACurrentPlayerShot: Boolean, pendingShot: PendingShot) {
+        if (isACurrentPlayerShot) {
+            currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged))
+        } else {
+            currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = currentPlayerShotSize + 1)))
+        }
         navigateToCreateOrEditPlayer()
     }
 

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -25,7 +25,6 @@ import com.nicholas.rutherford.track.your.shot.helper.extensions.toType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -77,6 +76,7 @@ class LogShotViewModel(
 
         scope.launch {
             val declaredShot = declaredShotRepository.fetchDeclaredShotFromId(id = shotType)
+
             val player = if (isExistingPlayer) {
                 playerRepository.fetchPlayerById(id = playerId)
             } else {
@@ -368,6 +368,7 @@ class LogShotViewModel(
                         ),
                         isPendingPlayer = isExistingPlayer
                     )
+
                     if (viewCurrentExistingShot) {
                         // todo -> we need  to check to make sure theres actual changes before we create a pending shot for current shot logged
                         // so in this case, the pendingShot should not equal the shot passed in as a param being the active shot
@@ -406,13 +407,11 @@ class LogShotViewModel(
             )
         }
 
-    internal suspend fun updatePendingShot(pendingShot: PendingShot) {
-        currentPendingShot.shotsStateFlow.collectLatest { pendingShotlogged ->
-            val pendingShotLogged = pendingShotlogged.first()
-            currentPendingShot.deleteShot(shotLogged = pendingShotLogged)
-            currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = pendingShotLogged.shotLogged.id)))
-            navigateToCreateOrEditPlayer()
-        }
+    internal fun updatePendingShot(pendingShot: PendingShot) {
+        val firstShotLogged = currentPendingShot.fetchPendingShots().first()
+        currentPendingShot.deleteShot(shotLogged = firstShotLogged)
+        currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = firstShotLogged.shotLogged.id)))
+        navigateToCreateOrEditPlayer()
     }
 
     internal fun createPendingShot(isACurrentPlayerShot: Boolean, pendingShot: PendingShot) {

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -365,11 +365,11 @@ class LogShotViewModel(
                         isPendingPlayer = isExistingPlayer
                     )
                     if (viewCurrentExistingShot) {
-                        //todo -> we need  to check to make sure theres actual changes before we create a pending shot for current shot logged
+                        // todo -> we need  to check to make sure theres actual changes before we create a pending shot for current shot logged
                         // so in this case, the pendingShot should not equal the shot passed in as a param being the active shot
                         createPendingShotForCurrentShot(pendingShot = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = shotId)))
                     } else if (viewCurrentPendingShot) {
-                        //todo -> we need  to check to make sure theres actual changes before we update pending shot
+                        // todo -> we need  to check to make sure theres actual changes before we update pending shot
                         // so in this case, the pendingShot should not equal the shot passed in as a param
                         updatePendingShot(pendingShot = pendingShot)
                     } else {

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -48,6 +48,7 @@ class LogShotViewModel(
 
     internal var isExistingPlayer = false
     private var playerId = 0
+    internal var shotType = 0
     internal var shotId = 0
 
     internal var currentPlayer: Player? = null
@@ -60,6 +61,7 @@ class LogShotViewModel(
     fun updateIsExistingPlayerAndId(
         isExistingPlayerArgument: Boolean,
         playerIdArgument: Int,
+        shotTypeArgument: Int,
         shotIdArgument: Int,
         viewCurrentExistingShotArgument: Boolean,
         viewCurrentPendingShotArgument: Boolean
@@ -68,12 +70,13 @@ class LogShotViewModel(
 
         this.isExistingPlayer = isExistingPlayerArgument
         this.playerId = playerIdArgument
+        this.shotType = shotTypeArgument
         this.shotId = shotIdArgument
         this.viewCurrentExistingShot = viewCurrentExistingShotArgument
         this.viewCurrentPendingShot = viewCurrentPendingShotArgument
 
         scope.launch {
-            val declaredShot = declaredShotRepository.fetchDeclaredShotFromId(id = shotId)
+            val declaredShot = declaredShotRepository.fetchDeclaredShotFromId(id = shotType)
             val player = if (isExistingPlayer) {
                 playerRepository.fetchPlayerById(id = playerId)
             } else {

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -52,7 +52,7 @@ class LogShotViewModel(
     internal var currentPlayer: Player? = null
     internal var currentDeclaredShot: DeclaredShot? = null
 
-    internal var currentPlayerShotSize = 0
+    private var currentPlayerShotSize = 0
     internal var viewCurrentExistingShot = false
     internal var viewCurrentPendingShot = false
 
@@ -98,7 +98,7 @@ class LogShotViewModel(
         }
     }
 
-    internal suspend fun updateStateForViewShot() {
+    private suspend fun updateStateForViewShot() {
         if (viewCurrentExistingShot) {
             currentPlayer?.shotsLoggedList?.first { shotLogged -> shotLogged.id == shotId }?.let { shot ->
                 logShotMutableStateFlow.update { state ->
@@ -364,10 +364,13 @@ class LogShotViewModel(
                         ),
                         isPendingPlayer = isExistingPlayer
                     )
-                    println("get here test $viewCurrentPendingShot")
                     if (viewCurrentExistingShot) {
-                        // todo -> update for existing shot
+                        //todo -> we need  to check to make sure theres actual changes before we create a pending shot for current shot logged
+                        // so in this case, the pendingShot should not equal the shot passed in as a param being the active shot
+                        createPendingShotForCurrentShot(pendingShot = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = shotId)))
                     } else if (viewCurrentPendingShot) {
+                        //todo -> we need  to check to make sure theres actual changes before we update pending shot
+                        // so in this case, the pendingShot should not equal the shot passed in as a param
                         updatePendingShot(pendingShot = pendingShot)
                     } else {
                         createPendingShot(pendingShot = pendingShot)
@@ -393,7 +396,7 @@ class LogShotViewModel(
             )
         }
 
-    internal suspend fun updatePendingShot(pendingShot: PendingShot) {
+    private suspend fun updatePendingShot(pendingShot: PendingShot) {
         val pendingShotLogged = currentPendingShot.shotsStateFlow.first().first()
         currentPendingShot.deleteShot(shotLogged = pendingShotLogged)
         currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = pendingShotLogged.shotLogged.id)))
@@ -402,6 +405,11 @@ class LogShotViewModel(
 
     private fun createPendingShot(pendingShot: PendingShot) {
         currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = currentPlayerShotSize + 1)))
+        navigateToCreateOrEditPlayer()
+    }
+
+    private fun createPendingShotForCurrentShot(pendingShot: PendingShot) {
+        currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged))
         navigateToCreateOrEditPlayer()
     }
 

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -25,6 +25,7 @@ import com.nicholas.rutherford.track.your.shot.helper.extensions.toType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -402,14 +403,16 @@ class LogShotViewModel(
             )
         }
 
-    private suspend fun updatePendingShot(pendingShot: PendingShot) {
-        val pendingShotLogged = currentPendingShot.shotsStateFlow.first().first()
-        currentPendingShot.deleteShot(shotLogged = pendingShotLogged)
-        currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = pendingShotLogged.shotLogged.id)))
-        navigateToCreateOrEditPlayer()
+    internal suspend fun updatePendingShot(pendingShot: PendingShot) {
+        currentPendingShot.shotsStateFlow.collectLatest { pendingShotlogged ->
+            val pendingShotLogged = pendingShotlogged.first()
+            currentPendingShot.deleteShot(shotLogged = pendingShotLogged)
+            currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = pendingShotLogged.shotLogged.id)))
+            navigateToCreateOrEditPlayer()
+        }
     }
 
-    private fun createPendingShot(isACurrentPlayerShot: Boolean, pendingShot: PendingShot) {
+    internal fun createPendingShot(isACurrentPlayerShot: Boolean, pendingShot: PendingShot) {
         if (isACurrentPlayerShot) {
             currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged))
         } else {

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/pendingshot/CurrentPendingShot.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/pendingshot/CurrentPendingShot.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface CurrentPendingShot {
     val shotsStateFlow: Flow<List<PendingShot>>
 
+    fun fetchPendingShots(): List<PendingShot>
     fun createShot(shotLogged: PendingShot)
     fun deleteShot(shotLogged: PendingShot)
     fun clearShotList()

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/pendingshot/CurrentPendingShotImpl.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/pendingshot/CurrentPendingShotImpl.kt
@@ -9,6 +9,8 @@ class CurrentPendingShotImpl : CurrentPendingShot {
     internal val shotsMutableStateFlow: MutableStateFlow<List<PendingShot>> = MutableStateFlow(value = emptyList())
     override val shotsStateFlow: Flow<List<PendingShot>> = shotsMutableStateFlow.asStateFlow()
 
+    override fun fetchPendingShots(): List<PendingShot> = shotsMutableStateFlow.value
+
     override fun createShot(shotLogged: PendingShot) {
         val currentShotList = shotsMutableStateFlow.value
         shotsMutableStateFlow.value = currentShotList + listOf(shotLogged)

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigation.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigation.kt
@@ -6,6 +6,7 @@ interface SelectShotNavigation {
     fun navigateToLogShot(
         isExistingPlayer: Boolean,
         playerId: Int,
+        shotType: Int,
         shotId: Int,
         viewCurrentExistingShot: Boolean,
         viewCurrentPendingShot: Boolean

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigationImpl.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigationImpl.kt
@@ -12,6 +12,7 @@ class SelectShotNavigationImpl(private val navigator: Navigator) : SelectShotNav
     override fun navigateToLogShot(
         isExistingPlayer: Boolean,
         playerId: Int,
+        shotType: Int,
         shotId: Int,
         viewCurrentExistingShot: Boolean,
         viewCurrentPendingShot: Boolean
@@ -20,6 +21,7 @@ class SelectShotNavigationImpl(private val navigator: Navigator) : SelectShotNav
             navigationAction = NavigationActions.SelectShot.logShot(
                 isExistingPlayer = isExistingPlayer,
                 playerId = playerId,
+                shotType = shotType,
                 shotId = shotId,
                 viewCurrentExistingShot = viewCurrentExistingShot,
                 viewCurrentPendingShot = viewCurrentPendingShot

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotParams.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotParams.kt
@@ -10,5 +10,5 @@ data class SelectShotParams(
     val onnDeclaredShotItemClicked: (declaredShot: DeclaredShot) -> Unit,
     val onHelpIconClicked: () -> Unit,
     val updateIsExistingPlayerAndPlayerId: () -> Unit,
-    val onItemClicked: (id: Int) -> Unit
+    val onItemClicked: (shotType: Int) -> Unit
 )

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotScreen.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotScreen.kt
@@ -64,8 +64,8 @@ fun SelectShotScreen(selectShotParams: SelectShotParams) {
                     items(selectShotParams.state.declaredShotList) { declaredShot ->
                         DeclaredShotItem(
                             declaredShot = declaredShot,
-                            onItemClicked = { id ->
-                                selectShotParams.onItemClicked.invoke(id)
+                            onItemClicked = { type ->
+                                selectShotParams.onItemClicked.invoke(type)
                             }
                         )
                     }
@@ -89,7 +89,7 @@ fun SelectShotScreen(selectShotParams: SelectShotParams) {
 @Composable
 fun DeclaredShotItem(
     declaredShot: DeclaredShot,
-    onItemClicked: (id: Int) -> Unit
+    onItemClicked: (type: Int) -> Unit
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModel.kt
@@ -126,7 +126,7 @@ class SelectShotViewModel(
         } else {
             pendingPlayerRepository.fetchPlayerById(id = playerId)?.let { player ->
                 determineShotId(player = player)
-            }?: Constants.DEFAULT_SHOT_ID
+            } ?: Constants.DEFAULT_SHOT_ID
         }
     }
 
@@ -143,6 +143,5 @@ class SelectShotViewModel(
                 )
             }
         }
-
     }
 }

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModel.kt
@@ -2,8 +2,12 @@ package com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot
 
 import androidx.lifecycle.ViewModel
 import com.nicholas.rutherford.track.your.shot.data.room.repository.DeclaredShotRepository
+import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlayerRepository
+import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
+import com.nicholas.rutherford.track.your.shot.data.room.response.Player
 import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
+import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import com.nicholas.rutherford.track.your.shot.helper.extensions.safeLet
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
@@ -19,6 +23,8 @@ class SelectShotViewModel(
     private val navigation: SelectShotNavigation,
     private val declaredShotRepository: DeclaredShotRepository,
     private val accountManager: AccountManager,
+    private val playerRepository: PlayerRepository,
+    private val pendingPlayerRepository: PendingPlayerRepository,
     private val createSharedPreferences: CreateSharedPreferences,
     private val readSharedPreferences: ReadSharedPreferences
 ) : ViewModel() {
@@ -104,15 +110,39 @@ class SelectShotViewModel(
         // todo show a alert of some sort with info
     }
 
-    fun onDeclaredShotItemClicked(shotId: Int) {
-        safeLet(isExistingPlayer, playerId) { isExisting, id ->
-            navigation.navigateToLogShot(
-                isExistingPlayer = isExisting,
-                playerId = id,
-                shotId = shotId,
-                viewCurrentExistingShot = false,
-                viewCurrentPendingShot = false
-            )
+    internal fun determineShotId(player: Player): Int {
+        return if (player.shotsLoggedList.isNotEmpty()) {
+            player.shotsLoggedList.size
+        } else {
+            Constants.DEFAULT_SHOT_ID
         }
+    }
+
+    internal suspend fun loggedShotId(isExistingPlayer: Boolean, playerId: Int): Int {
+        return if (isExistingPlayer) {
+            playerRepository.fetchPlayerById(playerId)?.let { player ->
+                determineShotId(player = player)
+            } ?: Constants.DEFAULT_SHOT_ID
+        } else {
+            pendingPlayerRepository.fetchPlayerById(id = playerId)?.let { player ->
+                determineShotId(player = player)
+            }?: Constants.DEFAULT_SHOT_ID
+        }
+    }
+
+    fun onDeclaredShotItemClicked(shotType: Int) {
+        safeLet(isExistingPlayer, playerId) { isExisting, id ->
+            scope.launch {
+                navigation.navigateToLogShot(
+                    isExistingPlayer = isExisting,
+                    playerId = id,
+                    shotType = shotType,
+                    shotId = loggedShotId(isExistingPlayer = isExisting, playerId = id),
+                    viewCurrentExistingShot = false,
+                    viewCurrentPendingShot = false
+                )
+            }
+        }
+
     }
 }

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -622,6 +622,8 @@ class LogShotViewModelTest {
             verify { currentPendingShot.createShot(any()) }
             verify { logShotViewModel.navigateToCreateOrEditPlayer() }
         }
+
+        //todo validate each and every other instance here
     }
 
     @Nested

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigationImplTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigationImplTest.kt
@@ -56,6 +56,7 @@ class SelectShotNavigationImplTest {
         val isExistingPlayer = false
         val playerId = 5
         val shotId = 3
+        val shotType = 4
         val viewCurrentExistingShot = false
         val viewCurrentPendingShot = false
         val argumentCapture: CapturingSlot<NavigationAction> = slot()
@@ -64,6 +65,7 @@ class SelectShotNavigationImplTest {
             isExistingPlayer = isExistingPlayer,
             playerId = playerId,
             shotId = shotId,
+            shotType = shotType,
             viewCurrentExistingShot = viewCurrentExistingShot,
             viewCurrentPendingShot = viewCurrentPendingShot
         )
@@ -75,6 +77,7 @@ class SelectShotNavigationImplTest {
             isExistingPlayer = isExistingPlayer,
             playerId = playerId,
             shotId = shotId,
+            shotType = shotType,
             viewCurrentExistingShot = viewCurrentExistingShot,
             viewCurrentPendingShot = viewCurrentPendingShot
         )

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot
 
 import com.nicholas.rutherford.track.your.shot.data.room.repository.DeclaredShotRepository
+import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlayerRepository
+import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestDeclaredShot
 import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
@@ -37,6 +39,9 @@ class SelectShotViewModelTest {
 
     private val accountManager = mockk<AccountManager>(relaxed = true)
 
+    private val playerRepository = mockk<PlayerRepository>(relaxed = true)
+    private val pendingPlayerRepository = mockk<PendingPlayerRepository>(relaxed = true)
+
     private val createSharedPreferences = mockk<CreateSharedPreferences>(relaxed = true)
     private val readSharedPreferences = mockk<ReadSharedPreferences>(relaxed = true)
 
@@ -47,6 +52,8 @@ class SelectShotViewModelTest {
             navigation = navigation,
             declaredShotRepository = declaredShotRepository,
             accountManager = accountManager,
+            playerRepository = playerRepository,
+            pendingPlayerRepository = pendingPlayerRepository,
             createSharedPreferences = createSharedPreferences,
             readSharedPreferences = readSharedPreferences
         )
@@ -99,6 +106,8 @@ class SelectShotViewModelTest {
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
                 accountManager = accountManager,
+                playerRepository = playerRepository,
+                pendingPlayerRepository = pendingPlayerRepository,
                 createSharedPreferences = createSharedPreferences,
                 readSharedPreferences = readSharedPreferences
             )
@@ -126,6 +135,8 @@ class SelectShotViewModelTest {
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
                 accountManager = accountManager,
+                playerRepository = playerRepository,
+                pendingPlayerRepository = pendingPlayerRepository,
                 createSharedPreferences = createSharedPreferences,
                 readSharedPreferences = readSharedPreferences
             )
@@ -152,6 +163,8 @@ class SelectShotViewModelTest {
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
                 accountManager = accountManager,
+                playerRepository = playerRepository,
+                pendingPlayerRepository = pendingPlayerRepository,
                 createSharedPreferences = createSharedPreferences,
                 readSharedPreferences = readSharedPreferences
             )

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
@@ -5,6 +5,7 @@ import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlaye
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestDeclaredShot
+import com.nicholas.rutherford.track.your.shot.data.test.room.TestPlayer
 import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
@@ -18,6 +19,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -305,6 +307,142 @@ class SelectShotViewModelTest {
             selectShotViewModel.onBackButtonClicked()
 
             verify { navigation.popFromEditPlayer() }
+        }
+    }
+
+    @Nested
+    inner class DetermineShotId {
+
+        @Test
+        fun `when player shotLoggedList is not empty should return the size of list`() {
+            val player = TestPlayer().create()
+
+            Assertions.assertEquals(
+                selectShotViewModel.determineShotId(player = player),
+                1
+            )
+        }
+
+        @Test
+        fun `when player shotLoggedList is empty should default value of 0`() {
+            val player = TestPlayer().create().copy(shotsLoggedList = emptyList())
+
+            Assertions.assertEquals(
+                selectShotViewModel.determineShotId(player = player),
+                0
+            )
+        }
+    }
+
+    @Nested
+    inner class LoggedShotId {
+        val playerId = 2
+        val player = TestPlayer().create()
+
+        @Test
+        fun `when isExistingPlayer is true and fetch player by id returns null should return default value of 0`() = runTest {
+            coEvery { playerRepository.fetchPlayerById(id = playerId) } returns null
+
+            Assertions.assertEquals(
+                selectShotViewModel.loggedShotId(isExistingPlayer = true, playerId = playerId),
+                0
+            )
+        }
+
+        @Test
+        fun `when isExistingPlayer is true and fetch player by id returns player should return player shotLoggedList size`() = runTest {
+            coEvery { playerRepository.fetchPlayerById(id = playerId) } returns player
+
+            Assertions.assertEquals(
+                selectShotViewModel.loggedShotId(isExistingPlayer = true, playerId = playerId),
+                player.shotsLoggedList.size
+            )
+        }
+
+        @Test
+        fun `when isExistingPlayer is set to false and fetch pending player by id returns null should return default value of 0`() = runTest {
+            coEvery { pendingPlayerRepository.fetchPlayerById(id = playerId) } returns null
+
+            Assertions.assertEquals(
+                selectShotViewModel.loggedShotId(isExistingPlayer = false, playerId = playerId),
+                0
+            )
+        }
+
+        @Test
+        fun `when isExistingPlayer is set to false and fetch pending player by id returns player should return player shotLoggedList size`() = runTest {
+            coEvery { pendingPlayerRepository.fetchPlayerById(id = playerId) } returns player
+
+            Assertions.assertEquals(
+                selectShotViewModel.loggedShotId(isExistingPlayer = false, playerId = playerId),
+                player.shotsLoggedList.size
+            )
+        }
+    }
+
+    @Nested
+    inner class OnDeclaredShotItemClicked {
+
+        @Test
+        fun `when isExistingPlayer is set to null should not call navigateToLogShot`() = runTest {
+            selectShotViewModel.isExistingPlayer = null
+            selectShotViewModel.playerId = 2
+
+            selectShotViewModel.onDeclaredShotItemClicked(shotType = 2)
+
+            verify(exactly = 0) {
+                navigation.navigateToLogShot(
+                    isExistingPlayer = any(),
+                    playerId = any(),
+                    shotType = any(),
+                    shotId = any(),
+                    viewCurrentExistingShot = any(),
+                    viewCurrentPendingShot = any()
+                )
+            }
+        }
+
+        @Test
+        fun `when playerId is set to null should not call navigateToLogShot`() = runTest {
+            selectShotViewModel.isExistingPlayer = false
+            selectShotViewModel.playerId = null
+
+            selectShotViewModel.onDeclaredShotItemClicked(shotType = 2)
+
+            verify(exactly = 0) {
+                navigation.navigateToLogShot(
+                    isExistingPlayer = any(),
+                    playerId = any(),
+                    shotType = any(),
+                    shotId = any(),
+                    viewCurrentExistingShot = any(),
+                    viewCurrentPendingShot = any()
+                )
+            }
+        }
+
+        @Test
+        fun `when playerId and isExistingPlayer are not set to null should call navigateToLogShot`() = runTest {
+            val playerId = 22
+            val player = TestPlayer().create()
+
+            coEvery { pendingPlayerRepository.fetchPlayerById(id = playerId) } returns player
+
+            selectShotViewModel.isExistingPlayer = false
+            selectShotViewModel.playerId = playerId
+
+            selectShotViewModel.onDeclaredShotItemClicked(shotType = 2)
+
+            verify {
+                navigation.navigateToLogShot(
+                    isExistingPlayer = false,
+                    playerId = playerId,
+                    shotType = 2,
+                    shotId = player.shotsLoggedList.size,
+                    viewCurrentExistingShot = false,
+                    viewCurrentPendingShot = false
+                )
+            }
         }
     }
 }

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerNavigation.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerNavigation.kt
@@ -10,6 +10,7 @@ interface CreateEditPlayerNavigation {
     fun navigateToLogShot(
         isExistingPlayer: Boolean,
         playerId: Int,
+        shotType: Int,
         shotId: Int,
         viewCurrentExistingShot: Boolean,
         viewCurrentPendingShot: Boolean

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerNavigationImpl.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerNavigationImpl.kt
@@ -23,12 +23,14 @@ class CreateEditPlayerNavigationImpl(private val navigator: Navigator) : CreateE
     override fun navigateToLogShot(
         isExistingPlayer: Boolean,
         playerId: Int,
+        shotType: Int,
         shotId: Int,
         viewCurrentExistingShot: Boolean,
         viewCurrentPendingShot: Boolean
     ) = navigator.navigate(
         navigationAction = NavigationActions.CreateEditPlayer.logShot(
             isExistingPlayer = isExistingPlayer,
+            shotType = shotType,
             playerId = playerId,
             shotId = shotId,
             viewCurrentExistingShot = viewCurrentExistingShot,

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerParams.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerParams.kt
@@ -16,6 +16,6 @@ data class CreateEditPlayerParams(
     val permissionNotGrantedForCameraAlert: () -> Unit,
     val permissionNotGrantedForReadMediaOrExternalStorageAlert: () -> Unit,
     val onSelectedCreateEditImageOption: (uri: String) -> CreateEditImageOption,
-    val onViewShotClicked: (shotId: Int) -> Unit,
-    val onViewPendingShotClicked: (shotId: Int) -> Unit
+    val onViewShotClicked: (shotTypoe: Int, shotId: Int) -> Unit,
+    val onViewPendingShotClicked: (shotType: Int, shotId: Int) -> Unit
 )

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerScreen.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerScreen.kt
@@ -246,11 +246,11 @@ fun CreateEditPlayerScreen(createEditPlayerParams: CreateEditPlayerParams) {
                         pendingShotList = createEditPlayerParams.state.pendingShots,
                         hintLogNewShotText = createEditPlayerParams.state.hintLogNewShotText,
                         onLogShotsClicked = createEditPlayerParams.onLogShotsClicked,
-                        onViewShotClicked = { shotId ->
-                            createEditPlayerParams.onViewShotClicked.invoke(shotId)
+                        onViewShotClicked = { shotType, shotId ->
+                            createEditPlayerParams.onViewShotClicked.invoke(shotType, shotId)
                         },
-                        onPendingShotClicked = { shotId ->
-                            createEditPlayerParams.onViewPendingShotClicked.invoke(shotId)
+                        onPendingShotClicked = { shotType, shotId ->
+                            createEditPlayerParams.onViewPendingShotClicked.invoke(shotType, shotId)
                         }
                     )
                 }

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -82,7 +82,7 @@ class CreateEditPlayerViewModel(
             createEditPlayerMutableStateFlow.update { state ->
                 state.copy(
                     pendingShots = pendingShotLoggedList.map { it.shotLogged },
-                    shots =  currentShotsNotPending()
+                    shots = currentShotsNotPending()
                 )
             }
         }

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.math.log
 
 const val RESET_SCREEN_DELAY_IN_MILLIS = 500L
 
@@ -79,10 +78,6 @@ class CreateEditPlayerViewModel(
     private fun processPendingShots(shotLoggedList: List<PendingShot>) {
         if (shotLoggedList.isNotEmpty()) {
             pendingShotLoggedList = shotLoggedList
-
-            pendingShotLoggedList.map {
-                println("the things we do for love ${it.shotLogged.shotType}")
-            }
 
             createEditPlayerMutableStateFlow.update { state ->
                 state.copy(
@@ -897,9 +892,8 @@ class CreateEditPlayerViewModel(
         if (hasLogShotsAccess()) {
             scope.launch {
                 existingOrPendingPlayerId()?.let { playerId ->
-                    val isExistingPlayer = editedPlayer != null
                     navigation.navigateToSelectShot(
-                        isExistingPlayer = isExistingPlayer,
+                        isExistingPlayer = editedPlayer != null,
                         playerId = playerId
                     )
                 }
@@ -910,7 +904,7 @@ class CreateEditPlayerViewModel(
     fun onViewPendingShotClicked(shotType: Int, shotId: Int) {
         scope.launch {
             navigation.navigateToLogShot(
-                isExistingPlayer = false,
+                isExistingPlayer = editedPlayer != null,
                 playerId = existingOrPendingPlayerId() ?: 0,
                 shotType = shotType,
                 shotId = shotId,

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.math.log
 
 const val RESET_SCREEN_DELAY_IN_MILLIS = 500L
 
@@ -78,6 +79,10 @@ class CreateEditPlayerViewModel(
     private fun processPendingShots(shotLoggedList: List<PendingShot>) {
         if (shotLoggedList.isNotEmpty()) {
             pendingShotLoggedList = shotLoggedList
+
+            pendingShotLoggedList.map {
+                println("the things we do for love ${it.shotLogged.shotType}")
+            }
 
             createEditPlayerMutableStateFlow.update { state ->
                 state.copy(
@@ -902,11 +907,12 @@ class CreateEditPlayerViewModel(
         }
     }
 
-    fun onViewPendingShotClicked(shotId: Int) {
+    fun onViewPendingShotClicked(shotType: Int, shotId: Int) {
         scope.launch {
             navigation.navigateToLogShot(
                 isExistingPlayer = false,
                 playerId = existingOrPendingPlayerId() ?: 0,
+                shotType = shotType,
                 shotId = shotId,
                 viewCurrentExistingShot = false,
                 viewCurrentPendingShot = true
@@ -914,11 +920,12 @@ class CreateEditPlayerViewModel(
         }
     }
 
-    fun onViewShotClicked(shotId: Int) {
+    fun onViewShotClicked(shotType: Int, shotId: Int) {
         scope.launch {
             navigation.navigateToLogShot(
                 isExistingPlayer = true,
                 playerId = existingOrPendingPlayerId() ?: 0,
+                shotType = shotType,
                 shotId = shotId,
                 viewCurrentExistingShot = true,
                 viewCurrentPendingShot = false

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -62,7 +62,7 @@ class CreateEditPlayerViewModel(
 
     internal var pendingShotLoggedList: List<PendingShot> = emptyList()
 
-    internal var hasChecked = false
+    internal var hasCheckedForExistingPlayer = false
 
     init {
         scope.launch { collectPendingShotsLogged() }
@@ -105,7 +105,7 @@ class CreateEditPlayerViewModel(
     }
 
     fun checkForExistingPlayer(firstNameArgument: String?, lastNameArgument: String?) {
-        if (!hasChecked) {
+        if (!hasCheckedForExistingPlayer) {
             scope.launch {
                 safeLet(firstNameArgument, lastNameArgument) { firstName, lastName ->
                     if (firstName.isNotEmpty() && lastName.isNotEmpty()) {
@@ -124,7 +124,7 @@ class CreateEditPlayerViewModel(
                 }
             }
 
-            hasChecked = true
+            hasCheckedForExistingPlayer = true
         }
     }
 
@@ -224,7 +224,7 @@ class CreateEditPlayerViewModel(
         pendingPlayers = emptyList()
         pendingShotLoggedList = emptyList()
         editedPlayer = null
-        hasChecked = false
+        hasCheckedForExistingPlayer = false
     }
 
     fun onImageUploadClicked(uri: Uri?) {

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
@@ -45,8 +45,8 @@ fun ColumnScope.ShotsContent(
     pendingShotList: List<ShotLogged>,
     hintLogNewShotText: String,
     onLogShotsClicked: () -> Unit,
-    onViewShotClicked: (shotId: Int) -> Unit,
-    onPendingShotClicked: (shotId: Int) -> Unit
+    onViewShotClicked: (shotType: Int, shotId: Int) -> Unit,
+    onPendingShotClicked: (shotType: Int, shotId: Int) -> Unit
 ) {
     if (shotList.isEmpty() && pendingShotList.isEmpty()) {
         ShotContentEmptyState(hintLogNewShotText = hintLogNewShotText, onLogShotsClicked = onLogShotsClicked)
@@ -74,13 +74,13 @@ fun ColumnScope.ShotsContent(
 @Composable
 private fun PendingShot(
     shot: ShotLogged,
-    onPendingShotClicked: (shotId: Int) -> Unit
+    onPendingShotClicked: (shotType: Int, shotId: Int) -> Unit
 ) {
     Card(
         modifier = Modifier
             .background(AppColors.White)
             .fillMaxWidth()
-            .clickable { onPendingShotClicked.invoke(shot.id) }
+            .clickable { onPendingShotClicked.invoke(shot.shotType, shot.id) }
             .padding(top = 4.dp, end = 4.dp),
         elevation = 2.dp
     ) {
@@ -88,7 +88,7 @@ private fun PendingShot(
             Row(
                 modifier = Modifier
                     .padding(8.dp)
-                    .clickable { onPendingShotClicked.invoke(shot.id) },
+                    .clickable { onPendingShotClicked.invoke(shot.shotType, shot.id) },
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
@@ -100,7 +100,7 @@ private fun PendingShot(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                IconButton(onClick = { onPendingShotClicked.invoke(shot.id) }) {
+                IconButton(onClick = { onPendingShotClicked.invoke(shot.shotType, shot.id) }) {
                     Icon(
                         imageVector = Icons.Filled.ArrowForward,
                         contentDescription = ""
@@ -114,7 +114,7 @@ private fun PendingShot(
 @Composable
 private fun ColumnScope.LoggedShot(
     shot: ShotLogged,
-    onViewShotClicked: (shotId: Int) -> Unit
+    onViewShotClicked: (shotType: Int, shotId: Int) -> Unit
 ) {
     Text(
         text = stringResource(id = R.string.shots),
@@ -128,7 +128,7 @@ private fun ColumnScope.LoggedShot(
         modifier = Modifier
             .background(AppColors.White)
             .fillMaxWidth()
-            .clickable { onViewShotClicked.invoke(shot.id) }
+            .clickable { onViewShotClicked.invoke(shot.shotType, shot.id) }
             .padding(
                 top = 16.dp,
                 end = 4.dp,
@@ -152,7 +152,7 @@ private fun ColumnScope.LoggedShot(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                IconButton(onClick = { onViewShotClicked.invoke(shot.id) }) {
+                IconButton(onClick = { onViewShotClicked.invoke(shot.shotType, shot.id) }) {
                     Icon(
                         imageVector = Icons.Filled.ArrowForward,
                         contentDescription = ""

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerNavigationImplTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerNavigationImplTest.kt
@@ -91,6 +91,7 @@ class CreateEditPlayerNavigationImplTest {
     fun `navigate to log shot`() {
         val isExistingPlayer = false
         val playerId = 5
+        val shotType = 4
         val shotId = 2
         val viewCurrentExistingShot = false
         val viewCurrentPendingShot = false
@@ -99,6 +100,7 @@ class CreateEditPlayerNavigationImplTest {
         createEditPlayerNavigationImpl.navigateToLogShot(
             isExistingPlayer = isExistingPlayer,
             playerId = playerId,
+            shotType = shotType,
             shotId = shotId,
             viewCurrentExistingShot = viewCurrentExistingShot,
             viewCurrentPendingShot = viewCurrentPendingShot
@@ -110,6 +112,7 @@ class CreateEditPlayerNavigationImplTest {
         val expectedAction = NavigationActions.CreateEditPlayer.logShot(
             isExistingPlayer = isExistingPlayer,
             playerId = playerId,
+            shotType = shotType,
             shotId = shotId,
             viewCurrentExistingShot = viewCurrentExistingShot,
             viewCurrentPendingShot = viewCurrentPendingShot

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -1920,12 +1920,16 @@ class CreateEditPlayerViewModelTest {
     fun `on view pending shot clicked should call log shot navigation`() {
         val player = TestPlayer().create()
 
-        createEditPlayerViewModel.onViewPendingShotClicked(shotId = player.shotsLoggedList.first().id)
+        createEditPlayerViewModel.onViewPendingShotClicked(
+            shotType = player.shotsLoggedList.first().shotType,
+            shotId = player.shotsLoggedList.first().id
+        )
 
         verify {
             navigation.navigateToLogShot(
                 isExistingPlayer = false,
                 playerId = 0,
+                shotType = player.shotsLoggedList.first().shotType,
                 shotId = player.shotsLoggedList.first().id,
                 viewCurrentExistingShot = false,
                 viewCurrentPendingShot = true
@@ -1937,12 +1941,16 @@ class CreateEditPlayerViewModelTest {
     fun `on view shot clicked should call log shot navigation`() {
         val player = TestPlayer().create()
 
-        createEditPlayerViewModel.onViewShotClicked(shotId = player.shotsLoggedList.first().id)
+        createEditPlayerViewModel.onViewShotClicked(
+            shotType = player.shotsLoggedList.first().shotType,
+            shotId = player.shotsLoggedList.first().id
+        )
 
         verify {
             navigation.navigateToLogShot(
                 isExistingPlayer = true,
                 playerId = 0,
+                shotType = player.shotsLoggedList.first().shotType,
                 shotId = player.shotsLoggedList.first().id,
                 viewCurrentExistingShot = true,
                 viewCurrentPendingShot = false

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -187,6 +187,28 @@ class CreateEditPlayerViewModelTest {
         private val player = TestPlayer().create()
 
         @Test
+        fun `when hasCheckedForExistingPlayer is set to to true should not update state`() {
+            Assertions.assertEquals(
+                createEditPlayerViewModel.createEditPlayerStateFlow.value,
+                CreateEditPlayerState()
+            )
+            Assertions.assertEquals(createEditPlayerViewModel.editedPlayer, null)
+
+            createEditPlayerViewModel.hasCheckedForExistingPlayer = true
+
+            createEditPlayerViewModel.checkForExistingPlayer(
+                firstNameArgument = null,
+                lastNameArgument = player.lastName
+            )
+
+            Assertions.assertEquals(createEditPlayerViewModel.editedPlayer, null)
+            Assertions.assertEquals(
+                createEditPlayerViewModel.createEditPlayerStateFlow.value,
+                CreateEditPlayerState()
+            )
+        }
+
+        @Test
         fun `when firstNameArgument is null should update toolbarNameResId to create player`() {
             Assertions.assertEquals(
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
@@ -203,6 +225,10 @@ class CreateEditPlayerViewModelTest {
             Assertions.assertEquals(
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState(toolbarNameResId = StringsIds.createPlayer)
+            )
+            Assertions.assertEquals(
+                createEditPlayerViewModel.hasCheckedForExistingPlayer,
+                true
             )
         }
 
@@ -224,6 +250,10 @@ class CreateEditPlayerViewModelTest {
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState(toolbarNameResId = StringsIds.createPlayer)
             )
+            Assertions.assertEquals(
+                createEditPlayerViewModel.hasCheckedForExistingPlayer,
+                true
+            )
         }
 
         @Test
@@ -244,6 +274,10 @@ class CreateEditPlayerViewModelTest {
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState(toolbarNameResId = StringsIds.createPlayer)
             )
+            Assertions.assertEquals(
+                createEditPlayerViewModel.hasCheckedForExistingPlayer,
+                true
+            )
         }
 
         @Test
@@ -263,6 +297,10 @@ class CreateEditPlayerViewModelTest {
             Assertions.assertEquals(
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState(toolbarNameResId = StringsIds.createPlayer)
+            )
+            Assertions.assertEquals(
+                createEditPlayerViewModel.hasCheckedForExistingPlayer,
+                true
             )
         }
 
@@ -285,6 +323,10 @@ class CreateEditPlayerViewModelTest {
             Assertions.assertEquals(
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState(toolbarNameResId = StringsIds.createPlayer)
+            )
+            Assertions.assertEquals(
+                createEditPlayerViewModel.hasCheckedForExistingPlayer,
+                true
             )
         }
 
@@ -316,6 +358,10 @@ class CreateEditPlayerViewModelTest {
                     hintLogNewShotText = "Press the \"Log Shots\" button to record shots for ${player.firstName} ${player.lastName}",
                     shots = player.shotsLoggedList
                 )
+            )
+            Assertions.assertEquals(
+                createEditPlayerViewModel.hasCheckedForExistingPlayer,
+                true
             )
         }
     }
@@ -561,6 +607,10 @@ class CreateEditPlayerViewModelTest {
         Assertions.assertEquals(
             createEditPlayerViewModel.editedPlayer,
             null
+        )
+        Assertions.assertEquals(
+            createEditPlayerViewModel.hasCheckedForExistingPlayer,
+            false
         )
     }
 

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -183,6 +183,54 @@ class CreateEditPlayerViewModelTest {
     }
 
     @Nested
+    inner class CurrentShotsNotPending {
+
+        @Test
+        fun `when editedPlayer is set to null should return a empty list`() {
+            val currentShotsArrayList: ArrayList<ShotLogged> = arrayListOf()
+
+            createEditPlayerViewModel.editedPlayer = null
+
+            Assertions.assertEquals(
+                createEditPlayerViewModel.currentShotsNotPending(),
+                currentShotsArrayList
+            )
+        }
+
+        @Test
+        fun `when editedPlayer is not set to null and pendingShotList contains the same ids of the logged list should return empty list`() {
+            val currentShotsArrayList: ArrayList<ShotLogged> = arrayListOf()
+
+            createEditPlayerViewModel.pendingShotLoggedList = listOf(
+                PendingShot(
+                    player = TestPlayer().create(),
+                    shotLogged = TestShotLogged.build(),
+                    isPendingPlayer = false
+                )
+            )
+            createEditPlayerViewModel.editedPlayer = TestPlayer().create()
+
+            Assertions.assertEquals(
+                createEditPlayerViewModel.currentShotsNotPending(),
+                currentShotsArrayList
+            )
+        }
+
+        @Test
+        fun `when editedPlayer is not set to null and pendingShotList returns empty should return expected logged list`() {
+            val currentShotsArrayList = listOf(TestShotLogged.build())
+
+            createEditPlayerViewModel.pendingShotLoggedList = listOf()
+            createEditPlayerViewModel.editedPlayer = TestPlayer().create()
+
+            Assertions.assertEquals(
+                createEditPlayerViewModel.currentShotsNotPending(),
+                currentShotsArrayList
+            )
+        }
+    }
+
+    @Nested
     inner class CheckForExistingPlayer {
         private val player = TestPlayer().create()
 

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/update/UpdateFirebaseUserInfoImpl.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/update/UpdateFirebaseUserInfoImpl.kt
@@ -21,7 +21,6 @@ class UpdateFirebaseUserInfoImpl(private val firebaseDatabase: FirebaseDatabase)
                 Constants.POSITION_VALUE to playerInfoRealtimeWithKeyResponse.playerInfo.positionValue,
                 Constants.SHOTS_LOGGED to playerInfoRealtimeWithKeyResponse.playerInfo.shotsLogged
             )
-        playerDataToUpdate.plus(mapOf())
         return callbackFlow {
             firebaseDatabase.getReference(Constants.USERS)
                 .child(Constants.ACCOUNT_INFO)

--- a/helper/constants/src/main/java/com/nicholas/rutherford/track/your/shot/helper/constants/Constants.kt
+++ b/helper/constants/src/main/java/com/nicholas/rutherford/track/your/shot/helper/constants/Constants.kt
@@ -14,6 +14,7 @@ object Constants {
     const val CENTER = 4
     const val CONTENT_LAST_UPDATED_PATH = "contentLastUpdated"
     const val DATE_PATTERN = "MMMM dd, yyyy"
+    const val DEFAULT_SHOT_ID = 0
     const val DELAY_IN_MILLISECONDS_BEFORE_LOGGING_OUT = 1000L
     const val DELAY_IN_MILLISECONDS_TO_SHOW_PROGRESS_MASK_ON_LOG_OUT = 3000L
     const val EMAIL = "email"

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationActions.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationActions.kt
@@ -113,6 +113,7 @@ object NavigationActions {
         fun logShot(
             isExistingPlayer: Boolean,
             playerId: Int,
+            shotType: Int,
             shotId: Int,
             viewCurrentExistingShot: Boolean,
             viewCurrentPendingShot: Boolean
@@ -120,6 +121,7 @@ object NavigationActions {
             override val destination = NavigationDestinationsWithParams.logShotWithParams(
                 isExistingPlayer = isExistingPlayer,
                 playerId = playerId,
+                shotType = shotType,
                 shotId = shotId,
                 viewCurrentExistingShot = viewCurrentExistingShot,
                 viewCurrentPendingShot = viewCurrentPendingShot
@@ -132,6 +134,7 @@ object NavigationActions {
         fun logShot(
             isExistingPlayer: Boolean,
             playerId: Int,
+            shotType: Int,
             shotId: Int,
             viewCurrentExistingShot: Boolean,
             viewCurrentPendingShot: Boolean
@@ -139,6 +142,7 @@ object NavigationActions {
             override val destination = NavigationDestinationsWithParams.logShotWithParams(
                 isExistingPlayer = isExistingPlayer,
                 playerId = playerId,
+                shotType = shotType,
                 shotId = shotId,
                 viewCurrentExistingShot = viewCurrentExistingShot,
                 viewCurrentPendingShot = viewCurrentPendingShot

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationDestinations.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationDestinations.kt
@@ -7,7 +7,7 @@ object NavigationDestinations {
     const val CREATE_EDIT_PLAYER_SCREEN = "createEditPlayerScreen"
     const val CREATE_EDIT_PLAYER_SCREEN_WITH_PARAMS = "createEditPlayerScreen/{firstName}/{lastName}"
     const val FORGOT_PASSWORD_SCREEN = "forgotPasswordScreen"
-    const val LOG_SHOT_WITH_PARAMS = "logShotScreen/{isExistingPlayer}/{playerId}/{shotId}/{viewCurrentExistingShot}/{viewCurrentPendingShot}"
+    const val LOG_SHOT_WITH_PARAMS = "logShotScreen/{isExistingPlayer}/{playerId}/{shotType}/{shotId}/{viewCurrentExistingShot}/{viewCurrentPendingShot}"
     const val LOG_SHOT_SCREEN = "logShotScreen"
     const val SELECT_SHOT_SCREEN = "selectShotScreen"
     const val SELECT_SHOT_SCREEN_WITH_PARAMS = "selectShotScreen/{isExistingPlayer}/{playerId}"

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationDestinationsWithParams.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationDestinationsWithParams.kt
@@ -12,10 +12,11 @@ object NavigationDestinationsWithParams {
     fun logShotWithParams(
         isExistingPlayer: Boolean,
         playerId: Int,
+        shotType: Int,
         shotId: Int,
         viewCurrentExistingShot: Boolean,
         viewCurrentPendingShot: Boolean
-    ): String = "${NavigationDestinations.LOG_SHOT_SCREEN}/$isExistingPlayer/$playerId/$shotId/$viewCurrentExistingShot/$viewCurrentPendingShot"
+    ): String = "${NavigationDestinations.LOG_SHOT_SCREEN}/$isExistingPlayer/$playerId/$shotType/$shotId/$viewCurrentExistingShot/$viewCurrentPendingShot"
 
     fun selectShotWithParams(
         isExistingPlayer: Boolean,

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NamedArguments.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NamedArguments.kt
@@ -7,6 +7,7 @@ object NamedArguments {
     const val LAST_NAME = "lastName"
     const val IS_EXISTING_PLAYER = "isExistingPlayer"
     const val PLAYER_ID = "playerId"
+    const val SHOT_TYPE= "shotType"
     const val SHOT_ID = "shotId"
     const val VIEW_CURRENT_EXISTING_SHOT = "viewCurrentExistingShot"
     const val VIEW_CURRENT_PENDING_SHOT = "viewCurrentPendingShot"

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NamedArguments.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NamedArguments.kt
@@ -7,7 +7,7 @@ object NamedArguments {
     const val LAST_NAME = "lastName"
     const val IS_EXISTING_PLAYER = "isExistingPlayer"
     const val PLAYER_ID = "playerId"
-    const val SHOT_TYPE= "shotType"
+    const val SHOT_TYPE = "shotType"
     const val SHOT_ID = "shotId"
     const val VIEW_CURRENT_EXISTING_SHOT = "viewCurrentExistingShot"
     const val VIEW_CURRENT_PENDING_SHOT = "viewCurrentPendingShot"

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NavArguments.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NavArguments.kt
@@ -19,6 +19,7 @@ object NavArguments {
     val logShot = listOf(
         navArgument(NamedArguments.IS_EXISTING_PLAYER) { type = NavType.BoolType },
         navArgument(NamedArguments.PLAYER_ID) { type = NavType.IntType },
+        navArgument(NamedArguments.SHOT_TYPE) { type = NavType.IntType},
         navArgument(NamedArguments.SHOT_ID) { type = NavType.IntType },
         navArgument(NamedArguments.VIEW_CURRENT_EXISTING_SHOT) { type = NavType.BoolType },
         navArgument(NamedArguments.VIEW_CURRENT_PENDING_SHOT) { type = NavType.BoolType }

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NavArguments.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NavArguments.kt
@@ -19,7 +19,7 @@ object NavArguments {
     val logShot = listOf(
         navArgument(NamedArguments.IS_EXISTING_PLAYER) { type = NavType.BoolType },
         navArgument(NamedArguments.PLAYER_ID) { type = NavType.IntType },
-        navArgument(NamedArguments.SHOT_TYPE) { type = NavType.IntType},
+        navArgument(NamedArguments.SHOT_TYPE) { type = NavType.IntType },
         navArgument(NamedArguments.SHOT_ID) { type = NavType.IntType },
         navArgument(NamedArguments.VIEW_CURRENT_EXISTING_SHOT) { type = NavType.BoolType },
         navArgument(NamedArguments.VIEW_CURRENT_PENDING_SHOT) { type = NavType.BoolType }

--- a/navigation/src/test/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationActionsTest.kt
+++ b/navigation/src/test/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationActionsTest.kt
@@ -234,16 +234,17 @@ class NavigationActionsTest {
             fun logShot() {
                 val isExistingPlayer = false
                 val playerId = 2
+                val shotType = 4
                 val shotId = 2
                 val viewCurrentExistingShot = false
                 val viewCurrentPendingShot = false
 
                 Assertions.assertEquals(
-                    Actions.SelectShot.logShot(isExistingPlayer = isExistingPlayer, playerId = playerId, shotId = shotId, viewCurrentExistingShot = viewCurrentExistingShot, viewCurrentPendingShot = viewCurrentPendingShot).destination,
-                    NavigationDestinationsWithParams.logShotWithParams(isExistingPlayer = isExistingPlayer, playerId = playerId, shotId = shotId, viewCurrentExistingShot = viewCurrentExistingShot, viewCurrentPendingShot = viewCurrentPendingShot)
+                    Actions.SelectShot.logShot(isExistingPlayer = isExistingPlayer, playerId = playerId, shotType = shotType, shotId = shotId, viewCurrentExistingShot = viewCurrentExistingShot, viewCurrentPendingShot = viewCurrentPendingShot).destination,
+                    NavigationDestinationsWithParams.logShotWithParams(isExistingPlayer = isExistingPlayer, playerId = playerId, shotType = shotType, shotId = shotId, viewCurrentExistingShot = viewCurrentExistingShot, viewCurrentPendingShot = viewCurrentPendingShot)
                 )
                 Assertions.assertEquals(
-                    Actions.SelectShot.logShot(isExistingPlayer = isExistingPlayer, playerId = playerId, shotId = shotId, viewCurrentExistingShot = viewCurrentExistingShot, viewCurrentPendingShot = viewCurrentExistingShot).navOptions,
+                    Actions.SelectShot.logShot(isExistingPlayer = isExistingPlayer, playerId = playerId, shotType = shotType, shotId = shotId, viewCurrentExistingShot = viewCurrentExistingShot, viewCurrentPendingShot = viewCurrentExistingShot).navOptions,
                     NavOptions.Builder().build()
                 )
             }

--- a/navigation/src/test/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NamedArgumentsTest.kt
+++ b/navigation/src/test/java/com/nicholas/rutherford/track/your/shot/navigation/arguments/NamedArgumentsTest.kt
@@ -16,6 +16,9 @@ class NamedArgumentsTest {
         Assertions.assertEquals(NamedArguments.IS_EXISTING_PLAYER, "isExistingPlayer")
         Assertions.assertEquals(NamedArguments.PLAYER_ID, "playerId")
 
+        Assertions.assertEquals(NamedArguments.SHOT_TYPE, "shotType")
+        Assertions.assertEquals(NamedArguments.SHOT_ID, "shotId")
+
         Assertions.assertEquals(NamedArguments.VIEW_CURRENT_EXISTING_SHOT, "viewCurrentExistingShot")
         Assertions.assertEquals(NamedArguments.VIEW_CURRENT_PENDING_SHOT, "viewCurrentPendingShot")
     }


### PR DESCRIPTION
### Trello
- https://trello.com/c/VWF828Ir/185-ability-to-edit-info-of-a-current-log-shot-in-edit-player-view

### Issues
- Currently in the edit player view the user does not have the ability to edit there current shot info. This is due to the fact that its technically outside the scope of an actual pending shot, in this case it would be an act ive shot since its logged in the database. We need to have functionality to make the shot that is updated a pending shot, which then would allow us to not show the current shot when navigating back to the UI of the player.The player should not see the shot as an active shot anymore and instead see it as a pending shot, in which they can save that pending shot which will be converted from pending shot to log shot.
- There is a couple of small clean up bugs that should be addressed. 

### Proposed Changes
- Allow for a user to edit info of a current shot. If they choose to do that, there current shot will be treated as a pending shot until the user wants to save there changes and link there pending shot to there current shot 
- Address these said bugs 
- Unit testing 

### TO-DO
- Update the UI of the pending shots so that way there in current sync on the create edit player screen, 
- Ability for the user to add more then just one given shot on a player. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 