### PR TITLE
nick: CreateEditPlayer workflow updates 

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -290,6 +290,7 @@ class AppModule {
         }
         viewModel {
             SelectShotViewModel(
+                application = get(),
                 scope = defaultCoroutineScope,
                 navigation = get(),
                 declaredShotRepository = get(),

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
@@ -320,7 +320,7 @@ fun NavigationComponent(
                         onBackButtonClicked = { selectShotViewModel.onBackButtonClicked() },
                         onCancelIconClicked = { selectShotViewModel.onCancelIconClicked() },
                         onnDeclaredShotItemClicked = {},
-                        onHelpIconClicked = {},
+                        onHelpIconClicked = { selectShotViewModel.onHelpIconClicked() },
                         updateIsExistingPlayerAndPlayerId = {
                             selectShotViewModel.updateIsExistingPlayerAndPlayerId(
                                 isExistingPlayerArgument = entry.arguments?.getBoolean(NamedArguments.IS_EXISTING_PLAYER),

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
@@ -22,6 +22,7 @@ object StringsIds {
     val currentAccountHasNotBeenVerifiedPleaseOpenEmailToVerifyAccount =
         R.string.current_account_has_not_been_verified_please_open_email_to_verify_account
     val currentPlayerHasNoChangesDescription = R.string.current_players_has_no_changes_description
+    val currentShotHasNoChangesDescription = R.string.current_shot_has_no_changes_description
     val dateShotsLogged = R.string.date_shots_logged
     val dateShotsTaken = R.string.date_shots_taken
     val deleteX = R.string.delete_x

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
@@ -21,6 +21,7 @@ object StringsIds {
     val createPlayer = R.string.create_player
     val currentAccountHasNotBeenVerifiedPleaseOpenEmailToVerifyAccount =
         R.string.current_account_has_not_been_verified_please_open_email_to_verify_account
+    val currentShotHasBeenUpdatedDescription = R.string.current_shot_has_been_updated_description
     val currentPlayerHasNoChangesDescription = R.string.current_players_has_no_changes_description
     val currentShotHasNoChangesDescription = R.string.current_shot_has_no_changes_description
     val dateShotsLogged = R.string.date_shots_logged
@@ -118,6 +119,7 @@ object StringsIds {
     val selectDate = R.string.select_date
     val settings = R.string.settings
     val shotPercentage = R.string.shot_percentage
+    val shotUpdated = R.string.shot_updated
     val shots = R.string.shots
     val shotsAttempted = R.string.shots_attempted
     val shotsMade = R.string.shots_made

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/feature/splash/StringsIds.kt
@@ -11,6 +11,7 @@ object StringsIds {
     val cameraPermissionHasBeenDeniedDescription = R.string.camera_permission_has_been_denied_description
     val center = R.string.center
     val checkIfAccountHaBeenVerified = R.string.check_if_account_has_been_verified
+    val chooseAShotToLogInfoDescription = R.string.choose_a_shot_to_log_info_description
     val chooseImageFromGallery = R.string.choose_image_from_gallery
     val chooseOption = R.string.choose_option
     val comparePlayersStats = R.string.compare_players_stats
@@ -21,7 +22,6 @@ object StringsIds {
     val currentAccountHasNotBeenVerifiedPleaseOpenEmailToVerifyAccount =
         R.string.current_account_has_not_been_verified_please_open_email_to_verify_account
     val currentPlayerHasNoChangesDescription = R.string.current_players_has_no_changes_description
-    val currentShotsX = R.string.current_shots_x
     val dateShotsLogged = R.string.date_shots_logged
     val dateShotsTaken = R.string.date_shots_taken
     val deleteX = R.string.delete_x
@@ -101,7 +101,6 @@ object StringsIds {
     val powerForward = R.string.power_forward
     val playerAlreadyHasBeenAddedDescription = R.string.player_already_has_been_added_description
     val playerCreationFailedPleaseTryAgain = R.string.player_creation_failed_please_try_again
-    val playerImage = R.string.player_image
     val playerIsInvalidPleaseTryAgain = R.string.player_is_invalid_please_try_again
     val players = R.string.players
     val playersFirstNameEmptyDescription = R.string.players_first_name_empty_description
@@ -114,16 +113,14 @@ object StringsIds {
     val resetPasswordEmailSent = R.string.reset_password_email_sent
     val resendEmail = R.string.resend_email
     val selectAShot = R.string.select_a_shot
+    val selectingAShot = R.string.selecting_a_shot
     val selectDate = R.string.select_date
     val settings = R.string.settings
-    val shotNameX = R.string.shot_name_x
     val shotPercentage = R.string.shot_percentage
     val shots = R.string.shots
     val shotsAttempted = R.string.shots_attempted
     val shotsMade = R.string.shots_made
-    val shotsMadeX = R.string.shots_made_x
     val shotsMadePercentage = R.string.shots_made_percentage
-    val shotsMadePercentageX = R.string.shots_made_percentage_x
     val shotsMissedPercentage = R.string.shots_missed_percentage
     val shotsMissed = R.string.shots_missed
     val shotsNotRecordedDescription = R.string.shots_not_recorded_description

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="create_player">Create Player</string>
     <string name="current_account_has_not_been_verified_please_open_email_to_verify_account">Current account has not been verified please open email to verify account.</string>
     <string name="current_players_has_no_changes_description">There haven\'t been any recent updates or modifications to the current player. Please make adjustments to the existing player to proceed.</string>
+    <string name="current_shot_has_no_changes_description">There haven\'t been any recent updates or modifications to this shot. Please make adjustments to the existing shot to proceed.</string>
     <string name="current_shots_x">Current Shots %s</string>
     <string name="date_shots_logged">Date Shots Logged</string>
     <string name="date_shots_taken">Date Shots Taken</string>

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="cancel">Cancel</string>
     <string name="center">Center</string>
     <string name="check_if_account_has_been_verified">Check if account has been verified</string>
+    <string name="choose_a_shot_to_log_info_description">Choose a shot to log its information. To view additional details about the shot, click \"Show More\",</string>
     <string name="choose_image_from_gallery">Choose Image From Gallery</string>
     <string name="choose_option">Choose Option</string>
     <string name="compare_players_stats">Compare Players &amp; Stats</string>
@@ -80,6 +81,7 @@
     <string name="reset_password_email_sent">Reset Password Email Sent</string>
     <string name="resend_email">Resend Email</string>
     <string name="select_a_shot">Select A Shot</string>
+    <string name="selecting_a_shot">Selecting A Shot</string>
     <string name="select_date">Select Date</string>
     <string name="password">Password</string>
     <string name="password_required">Password*</string>

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="create_player">Create Player</string>
     <string name="current_account_has_not_been_verified_please_open_email_to_verify_account">Current account has not been verified please open email to verify account.</string>
     <string name="current_players_has_no_changes_description">There haven\'t been any recent updates or modifications to the current player. Please make adjustments to the existing player to proceed.</string>
+    <string name="current_shot_has_been_updated_description">The current shot has been updated. To see the latest information, click on the shot to view the updates.</string>
     <string name="current_shot_has_no_changes_description">There haven\'t been any recent updates or modifications to this shot. Please make adjustments to the existing shot to proceed.</string>
     <string name="current_shots_x">Current Shots %s</string>
     <string name="date_shots_logged">Date Shots Logged</string>
@@ -109,6 +110,7 @@
     <string name="remove_image">Remove Image</string>
     <string name="settings">Settings</string>
     <string name="shot_percentage">%s %%</string>
+    <string name="shot_updated">Shot Updated</string>
     <string name="shots">Shots</string>
     <string name="shots_attempted">Shots Attempted</string>
     <string name="shots_made">Shots Made</string>

--- a/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/response/ShotLogged.kt
+++ b/data/room/src/main/java/com/nicholas/rutherford/track/your/shot/data/room/response/ShotLogged.kt
@@ -26,3 +26,15 @@ data class ShotLogged(
     @ColumnInfo(name = "isPending")
     val isPending: Boolean
 )
+
+fun ShotLogged.isTheSame(shotCompared: ShotLogged): Boolean {
+    return this.shotName == shotCompared.shotName &&
+        this.shotType == shotCompared.shotType &&
+        this.shotsAttempted == shotCompared.shotsAttempted &&
+        this.shotsMade == shotCompared.shotsMade &&
+        this.shotsMissed == shotCompared.shotsMissed &&
+        this.shotsMadePercentValue == shotCompared.shotsMadePercentValue &&
+        this.shotsMissedPercentValue == shotCompared.shotsMissedPercentValue &&
+        this.shotsAttemptedMillisecondsValue == shotCompared.shotsAttemptedMillisecondsValue &&
+        this.shotsLoggedMillisecondsValue == shotCompared.shotsLoggedMillisecondsValue
+}

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -8,6 +8,7 @@ import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerReposi
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
 import com.nicholas.rutherford.track.your.shot.data.room.response.ShotLogged
+import com.nicholas.rutherford.track.your.shot.data.room.response.isTheSame
 import com.nicholas.rutherford.track.your.shot.data.shared.InputInfo
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.AlertConfirmAndDismissButton
@@ -57,6 +58,7 @@ class LogShotViewModel(
     internal var viewCurrentExistingShot = false
     internal var viewCurrentPendingShot = false
 
+    internal var initialShotLogged: ShotLogged? = null
     fun updateIsExistingPlayerAndId(
         isExistingPlayerArgument: Boolean,
         playerIdArgument: Int,
@@ -154,6 +156,22 @@ class LogShotViewModel(
                 }
             }
         }
+
+        initialShotLogged = ShotLogged(
+                id = 0, // does not matter since were ignoring this field
+                shotName = logShotMutableStateFlow.value.shotName,
+                shotType = currentDeclaredShot?.id ?: 0,
+                shotsAttempted = logShotMutableStateFlow.value.shotsAttempted,
+                shotsMade = logShotMutableStateFlow.value.shotsMade,
+                shotsMissed = logShotMutableStateFlow.value.shotsMissed,
+                shotsMadePercentValue = convertPercentageToDouble(percentage = logShotMutableStateFlow.value.shotsMadePercentValue),
+                shotsMissedPercentValue = convertPercentageToDouble(percentage = logShotMutableStateFlow.value.shotsMissedPercentValue),
+                shotsAttemptedMillisecondsValue = convertValueToDate(value = logShotMutableStateFlow.value.shotsTakenDateValue)?.time
+                    ?: 0L,
+                shotsLoggedMillisecondsValue = convertValueToDate(value = logShotMutableStateFlow.value.shotsLoggedDateValue)?.time
+                    ?: 0L,
+                isPending = true // does not matter since were ignoring this field
+            )
     }
 
     fun onDateShotsTakenClicked() {
@@ -317,7 +335,7 @@ class LogShotViewModel(
         )
     }
 
-    fun shotEntryInvalidAlert(shotsMade: Int, shotsMissed: Int, shotsAttemptedMillisecondsValue: Long): Alert? {
+    internal fun shotEntryInvalidAlert(shotsMade: Int, shotsMissed: Int, shotsAttemptedMillisecondsValue: Long): Alert? {
         val description: String? = if (shotsMade == 0) {
             application.getString(StringsIds.shotsNotRecordedDescription)
         } else if (shotsMissed == 0) {
@@ -335,6 +353,11 @@ class LogShotViewModel(
         }
     }
 
+    internal fun disableProgressAndShowAlert(alert: Alert) {
+        navigation.disableProgress()
+        navigation.alert(alert = alert)
+    }
+
     fun onSaveClicked() {
         scope.launch {
             currentPlayer?.let { player ->
@@ -346,8 +369,7 @@ class LogShotViewModel(
                     shotsMissed = state.shotsMissed,
                     shotsAttemptedMillisecondsValue = convertValueToDate(value = state.shotsTakenDateValue)?.time ?: 0
                 )?.let { alert ->
-                    navigation.disableProgress()
-                    navigation.alert(alert = alert)
+                    disableProgressAndShowAlert(alert = alert)
                 } ?: run {
                     val pendingShot = PendingShot(
                         player = player,
@@ -370,16 +392,16 @@ class LogShotViewModel(
                     )
 
                     if (viewCurrentExistingShot) {
-                        // todo -> we need  to check to make sure theres actual changes before we create a pending shot for current shot logged
-                        // so in this case, the pendingShot should not equal the shot passed in as a param being the active shot
-                        createPendingShot(
+                        noChangesForShotAlert(pendingShotLogged = pendingShot.shotLogged)?.let { alert ->
+                            disableProgressAndShowAlert(alert = alert)
+                        }?: createPendingShot(
                             isACurrentPlayerShot = true,
                             pendingShot = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = shotId))
                         )
                     } else if (viewCurrentPendingShot) {
-                        // todo -> we need  to check to make sure theres actual changes before we update pending shot
-                        // so in this case, the pendingShot should not equal the shot passed in as a param
-                        updatePendingShot(pendingShot = pendingShot)
+                        noChangesForShotAlert(pendingShotLogged = pendingShot.shotLogged)?.let { alert ->
+                            disableProgressAndShowAlert(alert = alert)
+                        }?: updatePendingShot(pendingShot = pendingShot)
                     } else {
                         createPendingShot(
                             isACurrentPlayerShot = false,
@@ -407,7 +429,23 @@ class LogShotViewModel(
             )
         }
 
-    internal fun updatePendingShot(pendingShot: PendingShot) {
+    internal fun noChangesForShotAlert(pendingShotLogged: ShotLogged): Alert? {
+            initialShotLogged?.let { currentShot ->
+                if (currentShot.isTheSame(pendingShotLogged)) {
+                    return Alert(
+                        title = application.getString(StringsIds.noChangesMade),
+                        dismissButton = AlertConfirmAndDismissButton(
+                            buttonText = application.getString(StringsIds.gotIt)
+                        ),
+                        description = application.getString(StringsIds.currentShotHasNoChangesDescription)
+                    )
+                } else {
+                    return null
+                }
+            } ?:  return null
+    }
+
+    private fun updatePendingShot(pendingShot: PendingShot) {
         val firstShotLogged = currentPendingShot.fetchPendingShots().first()
         currentPendingShot.deleteShot(shotLogged = firstShotLogged)
         currentPendingShot.createShot(shotLogged = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = firstShotLogged.shotLogged.id)))

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -158,20 +158,20 @@ class LogShotViewModel(
         }
 
         initialShotLogged = ShotLogged(
-                id = 0, // does not matter since were ignoring this field
-                shotName = logShotMutableStateFlow.value.shotName,
-                shotType = currentDeclaredShot?.id ?: 0,
-                shotsAttempted = logShotMutableStateFlow.value.shotsAttempted,
-                shotsMade = logShotMutableStateFlow.value.shotsMade,
-                shotsMissed = logShotMutableStateFlow.value.shotsMissed,
-                shotsMadePercentValue = convertPercentageToDouble(percentage = logShotMutableStateFlow.value.shotsMadePercentValue),
-                shotsMissedPercentValue = convertPercentageToDouble(percentage = logShotMutableStateFlow.value.shotsMissedPercentValue),
-                shotsAttemptedMillisecondsValue = convertValueToDate(value = logShotMutableStateFlow.value.shotsTakenDateValue)?.time
-                    ?: 0L,
-                shotsLoggedMillisecondsValue = convertValueToDate(value = logShotMutableStateFlow.value.shotsLoggedDateValue)?.time
-                    ?: 0L,
-                isPending = true // does not matter since were ignoring this field
-            )
+            id = 0, // does not matter since were ignoring this field
+            shotName = logShotMutableStateFlow.value.shotName,
+            shotType = currentDeclaredShot?.id ?: 0,
+            shotsAttempted = logShotMutableStateFlow.value.shotsAttempted,
+            shotsMade = logShotMutableStateFlow.value.shotsMade,
+            shotsMissed = logShotMutableStateFlow.value.shotsMissed,
+            shotsMadePercentValue = convertPercentageToDouble(percentage = logShotMutableStateFlow.value.shotsMadePercentValue),
+            shotsMissedPercentValue = convertPercentageToDouble(percentage = logShotMutableStateFlow.value.shotsMissedPercentValue),
+            shotsAttemptedMillisecondsValue = convertValueToDate(value = logShotMutableStateFlow.value.shotsTakenDateValue)?.time
+                ?: 0L,
+            shotsLoggedMillisecondsValue = convertValueToDate(value = logShotMutableStateFlow.value.shotsLoggedDateValue)?.time
+                ?: 0L,
+            isPending = true // does not matter since were ignoring this field
+        )
     }
 
     fun onDateShotsTakenClicked() {
@@ -394,14 +394,14 @@ class LogShotViewModel(
                     if (viewCurrentExistingShot) {
                         noChangesForShotAlert(pendingShotLogged = pendingShot.shotLogged)?.let { alert ->
                             disableProgressAndShowAlert(alert = alert)
-                        }?: createPendingShot(
+                        } ?: createPendingShot(
                             isACurrentPlayerShot = true,
                             pendingShot = pendingShot.copy(shotLogged = pendingShot.shotLogged.copy(id = shotId))
                         )
                     } else if (viewCurrentPendingShot) {
                         noChangesForShotAlert(pendingShotLogged = pendingShot.shotLogged)?.let { alert ->
                             disableProgressAndShowAlert(alert = alert)
-                        }?: updatePendingShot(pendingShot = pendingShot)
+                        } ?: updatePendingShot(pendingShot = pendingShot)
                     } else {
                         createPendingShot(
                             isACurrentPlayerShot = false,
@@ -430,19 +430,19 @@ class LogShotViewModel(
         }
 
     internal fun noChangesForShotAlert(pendingShotLogged: ShotLogged): Alert? {
-            initialShotLogged?.let { currentShot ->
-                if (currentShot.isTheSame(pendingShotLogged)) {
-                    return Alert(
-                        title = application.getString(StringsIds.noChangesMade),
-                        dismissButton = AlertConfirmAndDismissButton(
-                            buttonText = application.getString(StringsIds.gotIt)
-                        ),
-                        description = application.getString(StringsIds.currentShotHasNoChangesDescription)
-                    )
-                } else {
-                    return null
-                }
-            } ?:  return null
+        initialShotLogged?.let { currentShot ->
+            if (currentShot.isTheSame(pendingShotLogged)) {
+                return Alert(
+                    title = application.getString(StringsIds.noChangesMade),
+                    dismissButton = AlertConfirmAndDismissButton(
+                        buttonText = application.getString(StringsIds.gotIt)
+                    ),
+                    description = application.getString(StringsIds.currentShotHasNoChangesDescription)
+                )
+            } else {
+                return null
+            }
+        } ?: return null
     }
 
     private fun updatePendingShot(pendingShot: PendingShot) {

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigation.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigation.kt
@@ -1,6 +1,9 @@
 package com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot
 
+import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
+
 interface SelectShotNavigation {
+    fun alert(alert: Alert)
     fun popFromCreatePlayer()
     fun popFromEditPlayer()
     fun navigateToLogShot(

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigationImpl.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotNavigationImpl.kt
@@ -1,10 +1,12 @@
 package com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot
 
+import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
 import com.nicholas.rutherford.track.your.shot.navigation.NavigationActions
 import com.nicholas.rutherford.track.your.shot.navigation.NavigationDestinations
 import com.nicholas.rutherford.track.your.shot.navigation.Navigator
 
 class SelectShotNavigationImpl(private val navigator: Navigator) : SelectShotNavigation {
+    override fun alert(alert: Alert) = navigator.alert(alertAction = alert)
     override fun popFromCreatePlayer() = navigator.pop(popRouteAction = NavigationDestinations.CREATE_EDIT_PLAYER_SCREEN)
 
     override fun popFromEditPlayer() = navigator.pop(popRouteAction = NavigationDestinations.CREATE_EDIT_PLAYER_SCREEN_WITH_PARAMS)

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModel.kt
@@ -1,11 +1,15 @@
 package com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot
 
+import android.app.Application
 import androidx.lifecycle.ViewModel
 import com.nicholas.rutherford.track.your.shot.data.room.repository.DeclaredShotRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
+import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
+import com.nicholas.rutherford.track.your.shot.data.shared.alert.AlertConfirmAndDismissButton
+import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import com.nicholas.rutherford.track.your.shot.helper.extensions.safeLet
@@ -19,6 +23,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class SelectShotViewModel(
+    private val application: Application,
     private val scope: CoroutineScope,
     private val navigation: SelectShotNavigation,
     private val declaredShotRepository: DeclaredShotRepository,
@@ -106,9 +111,17 @@ class SelectShotViewModel(
         }
     }
 
-    fun onHelpIconClicked() {
-        // todo show a alert of some sort with info
+    internal fun moreInfoAlert(): Alert {
+        return Alert(
+            title = application.getString(StringsIds.selectingAShot),
+            dismissButton = AlertConfirmAndDismissButton(
+                buttonText = application.getString(StringsIds.gotIt)
+            ),
+            description = application.getString(StringsIds.chooseAShotToLogInfoDescription)
+        )
     }
+
+    fun onHelpIconClicked() = navigation.alert(alert = moreInfoAlert())
 
     internal fun determineShotId(player: Player): Int {
         return if (player.shotsLoggedList.isNotEmpty()) {

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -10,6 +10,7 @@ import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.AlertConfirmAndDismissButton
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestDeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestPlayer
+import com.nicholas.rutherford.track.your.shot.data.test.room.TestShotLogged
 import com.nicholas.rutherford.track.your.shot.feature.players.shots.logshot.pendingshot.CurrentPendingShot
 import com.nicholas.rutherford.track.your.shot.feature.players.shots.logshot.pendingshot.PendingShot
 import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
@@ -588,6 +589,65 @@ class LogShotViewModelTest {
                     dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
                     description = description
                 )
+            )
+        }
+    }
+
+    @Test
+    fun `disable progress and show alert`() {
+        val alert = Alert(
+            title = "",
+            dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
+            description = "Test"
+        )
+
+        logShotViewModel.disableProgressAndShowAlert(alert = alert)
+
+        verify { navigation.disableProgress() }
+        verify { navigation.alert(alert = alert) }
+    }
+
+    @Nested
+    inner class NoChangesForShotAlert {
+        val pendingShotLogged = TestShotLogged.build()
+
+        @Test
+        fun `when initialShotLogged is set to null should return null`() {
+            logShotViewModel.initialShotLogged = null
+
+            Assertions.assertEquals(
+                logShotViewModel.noChangesForShotAlert(pendingShotLogged = pendingShotLogged),
+                null
+            )
+        }
+
+        @Test
+        fun `when initialShotLogged is not the same as pendingShotLogged should return null`() {
+            logShotViewModel.initialShotLogged = pendingShotLogged
+
+            Assertions.assertEquals(
+                logShotViewModel.noChangesForShotAlert(pendingShotLogged = pendingShotLogged.copy(shotsMissed = 111)),
+                null
+            )
+        }
+
+        @Test
+        fun `when initialShotLogged is the same as pendingShotLogged should return a alert`() {
+            val alert = Alert(
+                title = "No Changes Made",
+                dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
+                description = "There haven\'t been any recent updates or modifications to this shot. Please make adjustments to the existing shot to proceed."
+            )
+
+            every { application.getString(StringsIds.noChangesMade) } returns "No Changes Made"
+            every { application.getString(StringsIds.gotIt) } returns "Got It"
+            every { application.getString(StringsIds.currentShotHasNoChangesDescription) } returns "There haven\'t been any recent updates or modifications to this shot. Please make adjustments to the existing shot to proceed."
+            
+            logShotViewModel.initialShotLogged = pendingShotLogged
+
+            Assertions.assertEquals(
+                logShotViewModel.noChangesForShotAlert(pendingShotLogged = pendingShotLogged),
+                alert
             )
         }
     }

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -642,7 +642,7 @@ class LogShotViewModelTest {
             every { application.getString(StringsIds.noChangesMade) } returns "No Changes Made"
             every { application.getString(StringsIds.gotIt) } returns "Got It"
             every { application.getString(StringsIds.currentShotHasNoChangesDescription) } returns "There haven\'t been any recent updates or modifications to this shot. Please make adjustments to the existing shot to proceed."
-            
+
             logShotViewModel.initialShotLogged = pendingShotLogged
 
             Assertions.assertEquals(

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
@@ -1,11 +1,15 @@
 package com.nicholas.rutherford.track.your.shot.feature.players.shots.selectshot
 
+import android.app.Application
 import com.nicholas.rutherford.track.your.shot.data.room.repository.DeclaredShotRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
+import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
+import com.nicholas.rutherford.track.your.shot.data.shared.alert.AlertConfirmAndDismissButton
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestDeclaredShot
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestPlayer
+import com.nicholas.rutherford.track.your.shot.feature.splash.StringsIds
 import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
 import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
@@ -33,6 +37,8 @@ class SelectShotViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private val application = mockk<Application>(relaxed = true)
+
     private val scope = CoroutineScope(SupervisorJob() + testDispatcher)
 
     private val navigation = mockk<SelectShotNavigation>(relaxed = true)
@@ -50,6 +56,7 @@ class SelectShotViewModelTest {
     @BeforeEach
     fun beforeEach() {
         selectShotViewModel = SelectShotViewModel(
+            application = application,
             scope = scope,
             navigation = navigation,
             declaredShotRepository = declaredShotRepository,
@@ -104,6 +111,7 @@ class SelectShotViewModelTest {
             every { accountManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
 
             selectShotViewModel = SelectShotViewModel(
+                application = application,
                 scope = scope,
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
@@ -133,6 +141,7 @@ class SelectShotViewModelTest {
             every { accountManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
 
             selectShotViewModel = SelectShotViewModel(
+                application = application,
                 scope = scope,
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
@@ -161,6 +170,7 @@ class SelectShotViewModelTest {
             every { accountManager.loggedInDeclaredShotListStateFlow } returns MutableStateFlow(declaredShotList)
 
             selectShotViewModel = SelectShotViewModel(
+                application = application,
                 scope = scope,
                 navigation = navigation,
                 declaredShotRepository = declaredShotRepository,
@@ -310,6 +320,42 @@ class SelectShotViewModelTest {
         }
     }
 
+    @Test
+    fun `more info alert`() {
+        every { application.getString(StringsIds.selectingAShot) } returns "Selecting A Shot"
+        every { application.getString(StringsIds.gotIt) } returns "Got It"
+        every { application.getString(StringsIds.chooseAShotToLogInfoDescription) } returns "Choose a shot to log its information. To view additional details about the shot, click \"Show More\"."
+
+        val alert = Alert(
+            title = "Selecting A Shot",
+            dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
+            description = "Choose a shot to log its information. To view additional details about the shot, click \"Show More\"."
+        )
+
+        Assertions.assertEquals(
+            selectShotViewModel.moreInfoAlert(),
+            alert
+        )
+    }
+
+    @Test
+    fun `on help icon clicked`() {
+        every { application.getString(StringsIds.selectingAShot) } returns "Selecting A Shot"
+        every { application.getString(StringsIds.gotIt) } returns "Got It"
+        every { application.getString(StringsIds.chooseAShotToLogInfoDescription) } returns "Choose a shot to log its information. To view additional details about the shot, click \"Show More\"."
+
+        val alert = Alert(
+            title = "Selecting A Shot",
+            dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
+            description = "Choose a shot to log its information. To view additional details about the shot, click \"Show More\"."
+        )
+
+        selectShotViewModel.onHelpIconClicked()
+
+        verify { navigation.alert(alert = alert) }
+    }
+
+
     @Nested
     inner class DetermineShotId {
 
@@ -336,8 +382,8 @@ class SelectShotViewModelTest {
 
     @Nested
     inner class LoggedShotId {
-        val playerId = 2
-        val player = TestPlayer().create()
+        private val playerId = 2
+        private val player = TestPlayer().create()
 
         @Test
         fun `when isExistingPlayer is true and fetch player by id returns null should return default value of 0`() = runTest {

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/selectshot/SelectShotViewModelTest.kt
@@ -355,7 +355,6 @@ class SelectShotViewModelTest {
         verify { navigation.alert(alert = alert) }
     }
 
-
     @Nested
     inner class DetermineShotId {
 

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerViewModel.kt
@@ -85,7 +85,17 @@ class CreateEditPlayerViewModel(
                     shots = currentShotsNotPending()
                 )
             }
+
+            navigation.alert(alert = showUpdatedAlert())
         }
+    }
+
+    internal fun showUpdatedAlert(): Alert {
+        return Alert(
+            title = application.getString(StringsIds.shotUpdated),
+            dismissButton = AlertConfirmAndDismissButton(buttonText = application.getString(StringsIds.gotIt)),
+            description = application.getString(StringsIds.currentShotHasBeenUpdatedDescription)
+        )
     }
 
     internal fun currentShotsNotPending(): List<ShotLogged> {

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/ext/ShotsContent.kt
@@ -80,6 +80,10 @@ fun ColumnScope.ShotsContent(
             )
         }
     }
+
+    if (shotList.isNotEmpty() && pendingShotList.isEmpty()) {
+        LogNewShotButton(onLogShotsClicked = onLogShotsClicked)
+    }
 }
 
 @Composable
@@ -93,9 +97,9 @@ private fun LoggedShotCard(
             .fillMaxWidth()
             .clickable { onViewShotClicked.invoke(shot.shotType, shot.id) }
             .padding(
-                top = 16.dp,
+                top = 8.dp,
                 end = 4.dp,
-                bottom = 16.dp
+                bottom = 8.dp
             ),
         elevation = 2.dp
     ) {
@@ -124,6 +128,37 @@ private fun LoggedShotCard(
                 Icon(
                     imageVector = Icons.Filled.ArrowForward,
                     contentDescription = ""
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogNewShotButton(onLogShotsClicked: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppColors.White),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Button(
+                onClick = { onLogShotsClicked.invoke() },
+                shape = RoundedCornerShape(size = 50.dp),
+                modifier = Modifier
+                    .padding(vertical = Padding.twelve)
+                    .fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(backgroundColor = Colors.secondaryColor)
+            ) {
+                Text(
+                    text = "Log Shots",
+                    style = TextStyles.smallBold,
+                    textAlign = TextAlign.Center,
+                    color = Color.White
                 )
             }
         }

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -162,10 +162,22 @@ class CreateEditPlayerViewModelTest {
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState()
             )
+
+            verify(exactly = 0) { navigation.alert(alert = any())}
         }
 
         @Test
         fun `when 1currentPendingShot shotsStateFlow returns a list of 1 should update state`() = runTest {
+            every { application.getString(StringsIds.shotUpdated) } returns "Shot Updated"
+            every { application.getString(StringsIds.gotIt) } returns "Got It"
+            every { application.getString(StringsIds.currentShotHasBeenUpdatedDescription) } returns "The current shot has been updated. To see the latest information, click on the shot to view the updates"
+
+            val alert = Alert(
+                title = "Shot Updated",
+                dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
+                description = "The current shot has been updated. To see the latest information, click on the shot to view the updates"
+            )
+
             Assertions.assertEquals(
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState()
@@ -179,7 +191,27 @@ class CreateEditPlayerViewModelTest {
                 createEditPlayerViewModel.createEditPlayerStateFlow.value,
                 CreateEditPlayerState(pendingShots = listOf(pendingShot.shotLogged))
             )
+
+            verify { navigation.alert(alert = alert) }
         }
+    }
+
+    @Test
+    fun `show updated alert should return alert`() {
+        every { application.getString(StringsIds.shotUpdated) } returns "Shot Updated"
+        every { application.getString(StringsIds.gotIt) } returns "Got It"
+        every { application.getString(StringsIds.currentShotHasBeenUpdatedDescription) } returns "The current shot has been updated. To see the latest information, click on the shot to view the updates"
+
+        val alert = Alert(
+            title = "Shot Updated",
+            dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
+            description = "The current shot has been updated. To see the latest information, click on the shot to view the updates"
+        )
+
+        Assertions.assertEquals(
+            createEditPlayerViewModel.showUpdatedAlert(),
+            alert
+        )
     }
 
     @Nested

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/createeditplayer/CreateEditPlayerViewModelTest.kt
@@ -163,7 +163,7 @@ class CreateEditPlayerViewModelTest {
                 CreateEditPlayerState()
             )
 
-            verify(exactly = 0) { navigation.alert(alert = any())}
+            verify(exactly = 0) { navigation.alert(alert = any()) }
         }
 
         @Test


### PR DESCRIPTION
### Trello
- https://trello.com/c/BKNz2fyj/197-button-that-displays-if-you-have-no-pending-shots-and-at-least-one-saved-shot-to-allow-a-user-to-enter-another-shot

### Issues
- Currently the user is tied to only really add one shot for one player. The user should be able to add as many shots as they want to the given player, so long as the user does not have a current pending shot they need to convert to an active shot. 
- The user has no way of telling if there shot info has been updated or not. 
- On the select shot screen there is an info button that is supposed to display more info for the user. Currently that button is not clickable and doesn't display that more info. 
- We currently allow the user to update a pending or active shot, despite the fact they have no changes. We should check to make sure the user has no changes before we look to update there changes for there shot. 

### Proposed Changes
- Add a new button that allows the user to log shots, when they at least have one current active shot, and no pending shots. 
- Include a shot has updated dialog to indicate to the user that there shot info has been updated. 
- Make that button clickable, and display more info for the user. 
- Check before updating there pending shot changes, that they actually have changes. If they dont have any new changes, display an alert telling them they dont have new changes. 

### TO-DO
- Dark mode support, currently the app looks bad when we enable dark mode on our device. 
- Settings screen 
- Stuff to get ready for first release to the play store. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 