### PR TITLE
nick: Helper text for create account, clear state on login updates, and alert for error on create account flow updates

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -282,7 +282,8 @@ class AppModule {
                 application = androidApplication(),
                 navigation = get(),
                 buildType = get(),
-                accountManager = get()
+                accountManager = get(),
+                scope = defaultCoroutineScope
             )
         }
         viewModel {
@@ -355,7 +356,6 @@ class AppModule {
                 network = get(),
                 createFirebaseUserInfo = get(),
                 authenticationFirebase = get(),
-                userRepository = get(),
                 scope = defaultCoroutineScope
             )
         }

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
@@ -123,6 +123,7 @@ object StringsIds {
     val otherResources = R.string.other_resources
     val otherResourcesDescription = R.string.other_resources_description
     val password = R.string.password
+    val passwordHelperText = R.string.password_helper_text
     val passwordRequired = R.string.password_required
     val passwordIsNotInCorrectFormatPleaseEnterPasswordInCorrectFormat =
         R.string.password_is_not_in_correct_format_please_enter_password_in_correct_format

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
@@ -64,8 +64,10 @@ object StringsIds {
     val empty = R.string.empty
     val emptyField = R.string.empty_field
     val emptyFields = R.string.empty_fields
+    val emptyFieldsDescription = R.string.empty_fields_description
     val email = R.string.email
     val emailInUse = R.string.email_in_use
+    val emailInUseDescription = R.string.email_in_use_description
     val emailIsNotInCorrectFormatPleaseEnterEmailInCorrectFormat =
         R.string.email_is_not_in_correct_format_please_enter_email_in_correct_format
     val emailIsRequiredPleaseEnterAEmailToCreateAAccount =
@@ -204,6 +206,7 @@ object StringsIds {
     val username = R.string.username
     val usernameRequired = R.string.username_required
     val usernameInUse = R.string.username_in_use
+    val usernameInUseDescription = R.string.username_in_use_description
     val usernameIsNotInCorrectFormatPleaseEnterUsernameInCorrectFormat =
         R.string.username_is_not_in_correct_format_please_enter_username_in_correct_format
     val usernameIsRequiredPleaseEnterAUsernameToCreateAAccount =

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="forgot_password">Forgot Password</string>
     <string name="email">Email</string>
     <string name="email_in_use">Email in use</string>
+    <string name="email_in_use_description">This email is already in use on Track Your Shot. Please use a different email address.</string>
     <string name="email_has_been_sent_to_reset_password_please_follow_directions_to_reset_password">Email has been sent to reset password. Please follow directions to reset password.</string>
     <string name="email_has_been_sent_to_verify_account_please_open_sent_email_to_verify_account">Email has been sent to verify account. Please open sent email to verify account.</string>
     <string name="email_is_not_in_correct_format_please_enter_email_in_correct_format">Email is not in correct format. Please enter email in correct format</string>
@@ -71,6 +72,7 @@
     <string name="empty" translatable="false" />
     <string name="empty_field">Empty Field</string>
     <string name="empty_fields">Empty Fields</string>
+    <string name="empty_fields_description">Required information is missing to continue creating your account. Please provide the necessary details.</string>
     <string name="error">Error</string>
     <string name="error_creating_account">Error Creating Account</string>
     <string name="error_deleting_pending_account">Error deleting pending account</string>
@@ -191,6 +193,7 @@
     <string name="username">Username</string>
     <string name="username_required">Username*</string>
     <string name="username_in_use">Username in use</string>
+    <string name="username_in_use_description">This username is already in use on Track Your Shot. Please use a different username.</string>
     <string name="username_is_not_in_correct_format_please_enter_username_in_correct_format">Username is not in correct format. Please enter username in correct format</string>
     <string name="unable_to_create_account">Unable to create account</string>
     <string name="unable_to_delete_player_please_contact_support">Unable to delete player. Please contact support.</string>

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="selecting_a_shot">Selecting A Shot</string>
     <string name="select_date">Select Date</string>
     <string name="password">Password</string>
+    <string name="password_helper_text">Password must be at least 8 characters long and include: one lowercase letter (a–z), one uppercase letter (A–Z), one number (0–9), and one special character (e.g., @, $, !, %, *).</string>
     <string name="password_required">Password*</string>
     <string name="password_is_not_in_correct_format_please_enter_password_in_correct_format">Password is not in correct format. Please enter password in correct format</string>
     <string name="password_is_required_please_enter_a_password_to_create_a_account">Password is required. Please enter a password to create a account.</string>

--- a/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/TextFieldNoPadding.kt
+++ b/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/TextFieldNoPadding.kt
@@ -78,42 +78,42 @@ fun TextFieldNoPadding(
     val negativeOffSetPaddingX = (-8).dp
 
     Column {
-    BoxWithConstraints(
-        modifier = Modifier.clipToBounds()
-    ) {
-        TextField(
-            label = { Text(text = label) },
-            modifier = Modifier
-                .requiredWidth(maxWidth + Padding.sixteen)
-                .offset(x = negativeOffSetPaddingX)
-                .onFocusChanged { isFocused = it.isFocused }
-                .fillMaxWidth(),
-            value = value,
-            visualTransformation = visualTransformation,
-            keyboardOptions = keyboardOptions,
-            keyboardActions = KeyboardActions(
-                onDone = {
-                    keyboardController?.hide()
-                    isFocused = false
-                    shouldClearFocus = true
-                }
-            ),
-            onValueChange = { newUsername -> onValueChange.invoke(newUsername) },
-            textStyle = textStyle,
-            singleLine = singleLine,
-            colors = colors
-        )
-    }
-
-        if (isFocused) {
-        footerText?.let { value ->
-            Spacer(modifier = Modifier.height(Padding.eight))
-            Text(
-                text = value,
-                style = TextStyles.bodySmall,
-                color = AppColors.LightGray
+        BoxWithConstraints(
+            modifier = Modifier.clipToBounds()
+        ) {
+            TextField(
+                label = { Text(text = label) },
+                modifier = Modifier
+                    .requiredWidth(maxWidth + Padding.sixteen)
+                    .offset(x = negativeOffSetPaddingX)
+                    .onFocusChanged { isFocused = it.isFocused }
+                    .fillMaxWidth(),
+                value = value,
+                visualTransformation = visualTransformation,
+                keyboardOptions = keyboardOptions,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        keyboardController?.hide()
+                        isFocused = false
+                        shouldClearFocus = true
+                    }
+                ),
+                onValueChange = { newUsername -> onValueChange.invoke(newUsername) },
+                textStyle = textStyle,
+                singleLine = singleLine,
+                colors = colors
             )
         }
+
+        if (isFocused) {
+            footerText?.let { value ->
+                Spacer(modifier = Modifier.height(Padding.eight))
+                Text(
+                    text = value,
+                    style = TextStyles.bodySmall,
+                    color = AppColors.LightGray
+                )
+            }
         }
     }
 }

--- a/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/TextFieldNoPadding.kt
+++ b/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/TextFieldNoPadding.kt
@@ -3,7 +3,9 @@ package com.nicholas.rutherford.track.your.shot.compose.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.text.KeyboardActions
@@ -45,6 +47,7 @@ import com.nicholas.rutherford.track.your.shot.helper.ui.TextStyles
  * @param textStyle sets the [TextStyles] inside the [TextField]
  * @param singleLine sets whenever the [TextField] is a single line or not
  * @param colors sets the [TextFieldColors] inside the [TextField]
+ * @param footerText sets the [Text] of the footer of the [TextField] if not null
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -56,7 +59,8 @@ fun TextFieldNoPadding(
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
     textStyle: TextStyle = TextStyles.body,
     singleLine: Boolean = true,
-    colors: TextFieldColors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor)
+    colors: TextFieldColors = TextFieldDefaults.textFieldColors(backgroundColor = Colors.whiteColor),
+    footerText: String? = null
 ) {
     var isFocused by remember { mutableStateOf(false) }
 
@@ -67,11 +71,13 @@ fun TextFieldNoPadding(
     if (shouldClearFocus) {
         LocalFocusManager.current.clearFocus()
         shouldClearFocus = false
+        isFocused = false
     }
 
     // removes the starting padding of the TextField
     val negativeOffSetPaddingX = (-8).dp
 
+    Column {
     BoxWithConstraints(
         modifier = Modifier.clipToBounds()
     ) {
@@ -97,6 +103,18 @@ fun TextFieldNoPadding(
             singleLine = singleLine,
             colors = colors
         )
+    }
+
+        if (isFocused) {
+        footerText?.let { value ->
+            Spacer(modifier = Modifier.height(Padding.eight))
+            Text(
+                text = value,
+                style = TextStyles.bodySmall,
+                color = AppColors.LightGray
+            )
+        }
+        }
     }
 }
 

--- a/feature/create-account/build.gradle.kts
+++ b/feature/create-account/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     api(project(path = ":base-resources"))
     api(project(path = ":compose:components"))
     api(project(path = ":data:room"))
+    api(project(path = ":feature:players"))
     api(project(path = ":firebase:core"))
     api(project(path = ":firebase:util"))
     api(project(path = ":helper:compose-content-test-rule"))
@@ -86,19 +87,18 @@ dependencies {
     api(project(path = ":navigation"))
     api(project(path = ":shared-preference"))
 
+    implementation(Dependencies.Compose.activity)
     implementation(Dependencies.Compose.material)
     implementation(Dependencies.Compose.viewModel)
-    implementation(project(":feature:players"))
 
     testImplementation(Dependencies.Coroutine.test)
-
     testImplementation(Dependencies.Junit.Jupiter.api)
     testImplementation(Dependencies.Junit.Jupiter.params)
     testImplementation(Dependencies.Junit.junit)
-
     testImplementation(Dependencies.Mockk.core)
-    testImplementation(project(mapOf("path" to ":data-test:room")))
 
     testRuntimeOnly(Dependencies.Junit.Jupiter.engine)
-    testImplementation(project(":data-test:firebase"))
+
+    testImplementation(project(path = ":data-test:firebase"))
+    testImplementation(project(path = ":data-test:room"))
 }

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountScreen.kt
@@ -1,5 +1,6 @@
 package com.nicholas.rutherford.track.your.shot.feature.create.account.createaccount
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -35,6 +36,9 @@ import com.nicholas.rutherford.track.your.shot.helper.ui.TextStyles
 
 @Composable
 fun CreateAccountScreen(createAccountScreenParams: CreateAccountScreenParams) {
+    BackHandler(enabled = true) {
+        createAccountScreenParams.onBackButtonClicked.invoke()
+    }
     Content(
         ui = {
             CreateAccountScreenContent(createAccountScreenParams = createAccountScreenParams)

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountScreen.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountScreen.kt
@@ -70,7 +70,8 @@ fun CreateAccountScreenContent(createAccountScreenParams: CreateAccountScreenPar
             value = createAccountScreenParams.state.username ?: stringResource(id = StringsIds.empty),
             onValueChange = { newUsername ->
                 createAccountScreenParams.onUsernameValueChanged(newUsername)
-            }
+            },
+            footerText = "Username must be 8-30 characters long, contain only letters, numbers, underscores (_), and periods (.), start with a letter, and cannot have consecutive underscores or periods, or start/end with an underscore or period."
         )
 
         Spacer(modifier = Modifier.height(Padding.four))
@@ -81,7 +82,8 @@ fun CreateAccountScreenContent(createAccountScreenParams: CreateAccountScreenPar
             onValueChange = { newEmail ->
                 createAccountScreenParams.onEmailValueChanged(newEmail)
             },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+            footerText = "Email must include: a local part (e.g., yourname), an '@' symbol, and a domain (e.g., example.com)."
         )
 
         Spacer(modifier = Modifier.height(Padding.four))
@@ -93,7 +95,8 @@ fun CreateAccountScreenContent(createAccountScreenParams: CreateAccountScreenPar
                 createAccountScreenParams.onPasswordValueChanged(newPassword)
             },
             visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            footerText = stringResource(id = StringsIds.passwordHelperText)
         )
 
         Spacer(modifier = Modifier.height(Padding.eight))

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountViewModel.kt
@@ -19,10 +19,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-// Simple email expression. Doesn't allow numbers in the domain name and doesn't allow for top level domains
-// that are less than 2 or more than 3 letters (which is fine until they allow more).
-// Doesn't handle multiple &quot;.&quot; in the domain
-const val EMAIL_PATTERN = "^\\w+@[a-zA-Z_]+?\\.[a-zA-Z]{2,3}\$"
+// Improved email regex for basic validation.
+// - Allows dots, underscores, pluses, and other common characters in the local part of the email.
+// - Supports domains with numbers, hyphens, and multiple subdomains (e.g., "sub.domain.com").
+// - Permits top-level domains (TLDs) with 2 or more letters (e.g., ".com", ".info").
+// Limitations:
+// - Does not validate against all RFC 5322-compliant emails (e.g., quoted local parts or unusual characters).
+// - Does not verify the actual existence of the email domain or address.
+// - Uniqueness must still be checked separately in a database or storage
+const val EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
 
 // Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character
 const val PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@\$!%*?&])[A-Za-z\\d@\$!%*?&]{8,}\$"

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountViewModelTest.kt
@@ -2,8 +2,6 @@ package com.nicholas.rutherford.track.your.shot.feature.create.account.createacc
 
 import android.app.Application
 import com.nicholas.rutherford.track.your.shot.base.resources.StringsIds
-import com.nicholas.rutherford.track.your.shot.data.room.repository.UserRepository
-import com.nicholas.rutherford.track.your.shot.data.test.room.TestUser
 import com.nicholas.rutherford.track.your.shot.firebase.TestAuthenticateUserViaEmailFirebaseResponse
 import com.nicholas.rutherford.track.your.shot.firebase.TestCreateAccountFirebaseAuthResponse
 import com.nicholas.rutherford.track.your.shot.firebase.core.create.CreateFirebaseUserInfo
@@ -40,8 +38,6 @@ class CreateAccountViewModelTest {
     private val createFirebaseUserInfo = mockk<CreateFirebaseUserInfo>(relaxed = true)
     private val authenticationFirebase = mockk<AuthenticationFirebase>(relaxed = true)
 
-    private val userRepository = mockk<UserRepository>(relaxed = true)
-
     private val state = CreateAccountState(username = null, email = null, password = null)
 
     private val createAccountFirebaseAuthResponse = TestCreateAccountFirebaseAuthResponse().create()
@@ -62,7 +58,6 @@ class CreateAccountViewModelTest {
             network = network,
             createFirebaseUserInfo = createFirebaseUserInfo,
             authenticationFirebase = authenticationFirebase,
-            userRepository = userRepository,
             scope = scope
         )
     }
@@ -89,36 +84,10 @@ class CreateAccountViewModelTest {
     }
 
     @Test
-    fun `clear local declarations`() {
-        val emptyArray: ArrayList<String> = arrayListOf()
-
-        Assertions.assertEquals(viewModel.allStoredEmailsArrayList, emptyArray)
-        Assertions.assertEquals(viewModel.allStoredUsernamesArrayList, emptyArray)
-    }
-
-    @Test
     fun initializeCreateAccountState() {
         Assertions.assertEquals(
             viewModel.createAccountStateFlow.value,
             state
-        )
-    }
-
-    @Test
-    fun `updateStoredUsernamesAndEmailsArrayList when fetch all users return users should update allStoredEmailsArrayList and allStoredUsernamesArrayList`() = runTest {
-        val user = TestUser().create()
-
-        coEvery { userRepository.fetchAllUsers() } returns listOf(user)
-
-        viewModel.updateStoredUsernamesAndEmailsArrayList()
-
-        Assertions.assertEquals(
-            viewModel.allStoredEmailsArrayList,
-            arrayListOf(user.email)
-        )
-        Assertions.assertEquals(
-            viewModel.allStoredUsernamesArrayList,
-            arrayListOf(user.username)
         )
     }
 
@@ -310,40 +279,6 @@ class CreateAccountViewModelTest {
     }
 
     @Nested
-    inner class SetIsUsernameStoredInFirebase {
-        private val username = "username"
-
-        @Test
-        fun `username passed in is set to null should set isUsernameStoredInFirebase to false`() {
-            viewModel.isUsernameStoredInFirebase = false
-
-            viewModel.setIsUsernameStoredInFirebase(username = null)
-
-            Assertions.assertFalse(viewModel.isUsernameStoredInFirebase)
-        }
-
-        @Test
-        fun `username passed in is not null and is not contained in allStoredUsernamesArrayList should be set to false`() {
-            viewModel.isUsernameStoredInFirebase = false
-            viewModel.allStoredUsernamesArrayList = arrayListOf("username1", "username2")
-
-            viewModel.setIsUsernameStoredInFirebase(username = username)
-
-            Assertions.assertFalse(viewModel.isUsernameStoredInFirebase)
-        }
-
-        @Test
-        fun `username passed in is not null and is contained in allStoredUsernamesArrayList should be set to true`() {
-            viewModel.isUsernameStoredInFirebase = false
-            viewModel.allStoredUsernamesArrayList = arrayListOf(username, "username1", "username2")
-
-            viewModel.setIsUsernameStoredInFirebase(username = username)
-
-            Assertions.assertTrue(viewModel.isUsernameStoredInFirebase)
-        }
-    }
-
-    @Nested
     inner class SetIsEmailEmptyOrNull {
 
         @Test fun `when email is null should set isEmailEmptyOrNull to true`() {
@@ -454,49 +389,6 @@ class CreateAccountViewModelTest {
             Assertions.assertEquals(
                 viewModel.isEmailInNotCorrectFormat,
                 false
-            )
-        }
-    }
-
-    @Nested
-    inner class SetIsEmailStoredInFirebase {
-        private val testEmail = "testemail@yahoo.com"
-
-        @Test
-        fun `when email passed in is set to null should set isEmailStoredInFirebase to false`() {
-            viewModel.isEmailStoredInFirebase = false
-
-            viewModel.setIsEmailStoredInFirebase(email = null)
-
-            Assertions.assertEquals(
-                viewModel.isEmailStoredInFirebase,
-                false
-            )
-        }
-
-        @Test
-        fun `when email passed in is not set to null and allStoredEmailsArrayList does not contain email should set isEmailStoredInFirebase to false`() {
-            viewModel.isEmailStoredInFirebase = false
-            viewModel.allStoredEmailsArrayList = arrayListOf("test1email@yahoo.com", "test2email@yahoo.com")
-
-            viewModel.setIsEmailStoredInFirebase(email = testEmail)
-
-            Assertions.assertEquals(
-                viewModel.isEmailStoredInFirebase,
-                false
-            )
-        }
-
-        @Test
-        fun `when email passed in is not set to null and allStoredEmailsArrayList contains email should set isEmailStoredInFirebase to true`() {
-            viewModel.isEmailStoredInFirebase = false
-            viewModel.allStoredEmailsArrayList = arrayListOf(testEmail, "test1email@yahoo.com", "test2email@yahoo.com")
-
-            viewModel.setIsEmailStoredInFirebase(email = testEmail)
-
-            Assertions.assertEquals(
-                viewModel.isEmailStoredInFirebase,
-                true
             )
         }
     }

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/your/shot/feature/create/account/createaccount/CreateAccountViewModelTest.kt
@@ -75,7 +75,7 @@ class CreateAccountViewModelTest {
 
     @Test
     fun constants() {
-        Assertions.assertEquals(EMAIL_PATTERN, "^\\w+@[a-zA-Z_]+?\\.[a-zA-Z]{2,3}\$")
+        Assertions.assertEquals(EMAIL_PATTERN, "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
         Assertions.assertEquals(PASSWORD_PATTERN, "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@\$!%*?&])[A-Za-z\\d@\$!%*?&]{8,}\$")
         Assertions.assertEquals(USERNAME_PATTERN, "^(?=[a-zA-Z\\d._]{8,20}\$)(?!.*[_.]{2})[^_.].*[^_.]\$")
     }
@@ -127,9 +127,9 @@ class CreateAccountViewModelTest {
         private val regex = EMAIL_PATTERN.toRegex()
 
         private val invalidEmails = listOf(
-            "joe@123aspx.com",
-            "joe@web.info ",
-            "joe@company.co.uk"
+            "joe@123aspx@",
+            "joe@web.info.com ",
+            "user@domain.c"
         )
         private val validEmails = listOf(
             "oe@aol.com",

--- a/feature/login/src/test/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModelTest.kt
+++ b/feature/login/src/test/java/com/nicholas/rutherford/track/your/shot/feature/login/LoginViewModelTest.kt
@@ -7,6 +7,10 @@ import com.nicholas.rutherford.track.your.shot.build.type.BuildTypeImpl
 import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -21,6 +25,11 @@ class LoginViewModelTest {
     private var application = mockk<Application>(relaxed = true)
 
     private var accountManager = mockk<AccountManager>(relaxed = true)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val scope = CoroutineScope(SupervisorJob() + testDispatcher)
 
     private val sdkValue = 2
     private val debugVersionName = "debug"
@@ -42,7 +51,8 @@ class LoginViewModelTest {
             application = application,
             navigation = navigation,
             buildType = buildTypeDebug,
-            accountManager = accountManager
+            accountManager = accountManager,
+            scope = scope
         )
     }
 
@@ -60,7 +70,8 @@ class LoginViewModelTest {
                 application = application,
                 navigation = navigation,
                 buildType = buildTypeDebug,
-                accountManager = accountManager
+                accountManager = accountManager,
+                scope = scope
             )
 
             viewModel.updateLauncherDrawableIdState()
@@ -76,7 +87,8 @@ class LoginViewModelTest {
                 application = application,
                 navigation = navigation,
                 buildType = buildTypeStage,
-                accountManager = accountManager
+                accountManager = accountManager,
+                scope = scope
             )
 
             viewModel.updateLauncherDrawableIdState()
@@ -92,7 +104,8 @@ class LoginViewModelTest {
                 application = application,
                 navigation = navigation,
                 buildType = buildTypeRelease,
-                accountManager = accountManager
+                accountManager = accountManager,
+                scope = scope
             )
 
             viewModel.updateLauncherDrawableIdState()
@@ -194,8 +207,8 @@ class LoginViewModelTest {
         Assertions.assertEquals(
             LoginState(
                 launcherDrawableId = DrawablesIds.launcherRoundTest,
-                email = "",
-                password = ""
+                email = null,
+                password = null
             ),
             viewModel.loginMutableStateFlow.value
         )

--- a/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManager.kt
+++ b/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManager.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 interface AccountManager {
     val loggedInPlayerListStateFlow: StateFlow<List<Player>>
     val loggedInDeclaredShotListStateFlow: StateFlow<List<DeclaredShot>>
+    val hasLoggedInSuccessfulFlow: Flow<Boolean>
     val hasNoPlayersFlow: Flow<Boolean>
 
     fun logout()

--- a/helper/ui/src/main/java/com/nicholas/rutherford/track/your/shot/helper/ui/TextStyles.kt
+++ b/helper/ui/src/main/java/com/nicholas/rutherford/track/your/shot/helper/ui/TextStyles.kt
@@ -51,6 +51,12 @@ object TextStyles {
         fontFamily = FontFamily.Default
     )
 
+    val bodySmall = TextStyle(
+        fontSize = 12.sp,
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold
+    )
+
     val hyperLink = TextStyle(
         fontSize = 14.sp,
         fontFamily = FontFamily.Default,


### PR DESCRIPTION
### Trello
- https://trello.com/c/gdpYLL73/220-bug-take-a-look-at-the-validatefieldswithoptionalalert-function-found-in-createaccountviewmodel
- https://trello.com/c/jjRR0VZS/219-have-a-disclosure-of-user-requirements-when-creating-account-for-username-email-password

### Issues
- User on the create account workflow didn't really know what to enter for username, password, and email requirements. Different apps have different requirements, and we didn't really spell out in our cases what are the requirements for the app. 
- There was a bug where when we checked for errors in user entry on the create account workflow, that the error alerts didn't really make the most sense in the world. 
- Login and create account state wouldn't update correctly from both workflows. When a user logins in successfully then there state should be reset. When a user creates an account, if there info are valid then we should clear state from that screen as well. 

### Proposed Changes
- Introduce a footer to the text fields with no padding to ensure a user knows what to enter for each field. 
- Update alerts on create account workflow to make sure verbiage made sense. 
- \update login and create account states, to ensure that both clear the state as expected from both workflows. 

### TO-DO
- Start working on version 1.1 since version 1.0 is done after these changes. 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 