### PR TITLE
nick: Ability to delete a shot from a given player

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -304,6 +304,7 @@ class AppModule {
         viewModel {
             CreateEditPlayerViewModel(
                 application = androidApplication(),
+                deleteFirebaseUserInfo = get(),
                 createFirebaseUserInfo = get(),
                 updateFirebaseUserInfo = get(),
                 readFirebaseUserInfo = get(),
@@ -338,6 +339,7 @@ class AppModule {
                 declaredShotRepository = get(),
                 pendingPlayerRepository = get(),
                 playerRepository = get(),
+                deleteFirebaseUserInfo = get(),
                 currentPendingShot = get()
             )
         }

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -294,7 +294,6 @@ class AppModule {
                 network = get(),
                 accountManager = get(),
                 deleteFirebaseUserInfo = get(),
-                activeUserRepository = get(),
                 playersAdditionUpdates = get(),
                 playerRepository = get(),
                 pendingPlayerRepository = get(),

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
@@ -399,7 +399,8 @@ fun NavigationComponent(
                             },
                             onShotsMadeClicked = { logShotViewModel.onShotsMadeClicked() },
                             onShotsMissedClicked = { logShotViewModel.onShotsMissedClicked() },
-                            onSaveClicked = { logShotViewModel.onSaveClicked() }
+                            onSaveClicked = { logShotViewModel.onSaveClicked() },
+                            onDeleteShotClicked = { logShotViewModel.onDeleteShotClicked() }
                         )
                     )
                 }

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
@@ -167,6 +167,8 @@ object StringsIds {
     val selectDate = R.string.select_date
     val settings = R.string.settings
     val settingsHelpDescription = R.string.settings_help_description
+    val shotHasBeenDeleted = R.string.shot_has_been_deleted
+    val shotHasNotBeenDeleted = R.string.shot_has_not_been_deleted
     val shotPercentage = R.string.shot_percentage
     val shotUpdated = R.string.shot_updated
     val shots = R.string.shots
@@ -227,6 +229,8 @@ object StringsIds {
     val weWereUnableToSendEmailVerificationPleaseClickSendEmailVerificationToTryAgain =
         R.string.we_were_unable_to_send_email_verification_please_click_send_email_verification_to_try_again
     val xShot = R.string.x_shot
+    val xShotHasBeenRemovedDescription = R.string.x_shot_has_been_removed_description
+    val xShotHasNotBeenRemovedDescription = R.string.x_shot_has_not_been_removed_description
     val xShots = R.string.x_shots
     val yes = R.string.yes
     val yourPlayerCouldNotBeRetrievedDescription =

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
@@ -10,6 +10,8 @@ object StringsIds {
     val androidPermissionsUrl = R.string.android_permissions_url
     val accountSecurityDescription = R.string.account_security_description
     val areYouCertainYouWishToRemoveX = R.string.are_you_certain_you_wish_to_remove_x
+    val areYouSureYouWantToDeleteXShot =
+        R.string.are_you_sure_you_want_to_delete_x_shot
     val areYouSureYouWantLeaveTrackYourShot =
         R.string.are_you_sure_you_want_to_leave_track_your_shot
     val areYouSureYouWantToDeletePendingAccountDescription =
@@ -47,6 +49,7 @@ object StringsIds {
     val dateShotsTaken = R.string.date_shots_taken
     val deletePendingAccount = R.string.delete_pending_account
     val deletingPendingAccount = R.string.deleting_pending_account
+    val deleteShot = R.string.delete_Shot
     val deleteX = R.string.delete_x
     val devEmail = R.string.dev_email
     val deviceIsCurrentlyNotConnectedToInternetDesc =

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -155,6 +155,8 @@
     <string name="remove_image">Remove Image</string>
     <string name="settings">Settings</string>
     <string name="settings_help_description">On the settings page, you can view your account information, review terms and conditions, access app usage details, and learn about the permissions we request and why we need them.</string>
+    <string name="shot_has_been_deleted">Shot Has Been Deleted</string>
+    <string name="shot_has_not_been_deleted">Shot Hsa Not Been Deleted</string>
     <string name="shot_percentage">%s %%</string>
     <string name="shot_updated">Shot Updated</string>
     <string name="shots">Shots</string>
@@ -219,6 +221,8 @@
     <string name="voice_commands">Voice Commands</string>
     <string name="x_position_x_player_name" formatted="false">%s , %s</string>
     <string name="x_shot">%s Shot</string>
+    <string name="x_shot_has_been_removed_description">%s Shot has been removed from this player\'s shot history.</string>
+    <string name="x_shot_has_not_been_removed_description">%s Shot has not been removed from this player\'s shot history. Please try again to remove shot.</string>
     <string name="x_shots">%s Shots</string>
     <string name="x_shot_category">Category - %s</string>
     <string name="x_x">%s - %s</string>

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="acknowledge_and_agree_to_terms">Acknowledge / Agree To Terms</string>
     <string name="android_permissions_url" translatable="false">https://developer.android.com/guide/topics/permissions/overview</string>
     <string name="are_you_certain_you_wish_to_remove_x">Are you certain you wish to remove %s?</string>
-    <string name="are_you_sure_you_want_to_delete_x_shot">Are you sure you want to delete %s shot?</string>
+    <string name="are_you_sure_you_want_to_delete_x_shot">Are you sure you want to delete %s?</string>
     <string name="are_you_sure_you_want_to_leave_track_your_shot">Are you sure you want to leave Track Your Shot?</string>
     <string name="are_you_sure_you_want_to_delete_pending_account_description">Deleting your pending account will require you to either register a new account or log in to an existing one. Are you sure you want to proceed with deleting your pending account?</string>
     <string name="by_nicholas_rutherford">By Nicholas Rutherford</string>
@@ -221,7 +221,7 @@
     <string name="voice_commands">Voice Commands</string>
     <string name="x_position_x_player_name" formatted="false">%s , %s</string>
     <string name="x_shot">%s Shot</string>
-    <string name="x_shot_has_been_removed_description">%s Shot has been removed from this player\'s shot history.</string>
+    <string name="x_shot_has_been_removed_description">%s has been removed from this player\'s shot history.</string>
     <string name="x_shot_has_not_been_removed_description">%s Shot has not been removed from this player\'s shot history. Please try again to remove shot.</string>
     <string name="x_shots">%s Shots</string>
     <string name="x_shot_category">Category - %s</string>

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="acknowledge_and_agree_to_terms">Acknowledge / Agree To Terms</string>
     <string name="android_permissions_url" translatable="false">https://developer.android.com/guide/topics/permissions/overview</string>
     <string name="are_you_certain_you_wish_to_remove_x">Are you certain you wish to remove %s?</string>
+    <string name="are_you_sure_you_want_to_delete_x_shot">Are you sure you want to delete %s shot?</string>
     <string name="are_you_sure_you_want_to_leave_track_your_shot">Are you sure you want to leave Track Your Shot?</string>
     <string name="are_you_sure_you_want_to_delete_pending_account_description">Deleting your pending account will require you to either register a new account or log in to an existing one. Are you sure you want to proceed with deleting your pending account?</string>
     <string name="by_nicholas_rutherford">By Nicholas Rutherford</string>
@@ -46,6 +47,7 @@
     <string name="date_shots_taken">Date Shots Taken</string>
     <string name="delete_pending_account">Delete Pending Account</string>
     <string name="deleting_pending_account">Deleting Pending Account</string>
+    <string name="delete_Shot">Delete Shot</string>
     <string name="delete_x">Delete %s</string>
     <string name="dev_email" translatable="false">nicholasrutherforddeveloper@gmail.com</string>
     <string name="device_is_currently_not_connected_to_internet_desc">Device is currently not connected to internet. Please connect device to internet to complete action.</string>

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotParams.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotParams.kt
@@ -7,5 +7,6 @@ data class LogShotParams(
     val updateIsExistingPlayerAndPlayerId: () -> Unit,
     val onShotsMadeClicked: () -> Unit,
     val onShotsMissedClicked: () -> Unit,
-    val onSaveClicked: () -> Unit
+    val onSaveClicked: () -> Unit,
+    val onDeleteShotClicked: () -> Unit
 )

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotScreen.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotScreen.kt
@@ -2,13 +2,19 @@ package com.nicholas.rutherford.track.your.shot.feature.players.shots.logshot
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.ChevronRight
@@ -24,9 +30,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nicholas.rutherford.track.your.shot.AppColors
+import com.nicholas.rutherford.track.your.shot.base.resources.Colors
 import com.nicholas.rutherford.track.your.shot.base.resources.StringsIds
 import com.nicholas.rutherford.track.your.shot.compose.components.BaseRow
 import com.nicholas.rutherford.track.your.shot.compose.components.Content
@@ -77,6 +85,36 @@ fun LogShotContent(logShotParams: LogShotParams) {
             onShotsMissedClicked = logShotParams.onShotsMissedClicked
         )
         PlayerInfoContent(state = logShotParams.state)
+
+        if (logShotParams.state.deleteShotButtonVisible) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(AppColors.White),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Button(
+                        onClick = { logShotParams.onDeleteShotClicked.invoke() },
+                        shape = RoundedCornerShape(size = 50.dp),
+                        modifier = Modifier
+                            .padding(vertical = Padding.twelve)
+                            .fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(backgroundColor = Colors.secondaryColor)
+                    ) {
+                        Text(
+                            text = stringResource(id = StringsIds.deleteX, logShotParams.state.shotName),
+                            style = TextStyles.smallBold,
+                            textAlign = TextAlign.Center,
+                            color = Color.White
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotState.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotState.kt
@@ -10,5 +10,6 @@ data class LogShotState(
     val shotsMissed: Int = 0,
     val shotsAttempted: Int = 0,
     val shotsMadePercentValue: String = "",
-    val shotsMissedPercentValue: String = ""
+    val shotsMissedPercentValue: String = "",
+    val deleteShotButtonVisible: Boolean = false
 )

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -123,7 +123,8 @@ class LogShotViewModel(
                             shotsMade = shot.shotsMade.toDouble(),
                             shotsMissed = shot.shotsMissed.toDouble(),
                             isShotsMade = false
-                        )
+                        ),
+                        deleteShotButtonVisible = true
                     )
                 }
             }
@@ -151,7 +152,8 @@ class LogShotViewModel(
                             shotsMade = shot.shotsMade.toDouble(),
                             shotsMissed = shot.shotsMissed.toDouble(),
                             isShotsMade = false
-                        )
+                        ),
+                        deleteShotButtonVisible = false
                     )
                 }
             }
@@ -509,4 +511,21 @@ class LogShotViewModel(
     }
 
     fun onBackClicked() = navigation.pop()
+
+    fun deleteShotAlert(): Alert {
+        return Alert(
+            title = application.getString(StringsIds.deleteShot),
+            description = application.getString(StringsIds.areYouSureYouWantToDeleteXShot, logShotMutableStateFlow.value.shotName),
+            confirmButton = AlertConfirmAndDismissButton(
+                buttonText = application.getString(StringsIds.yes),
+                onButtonClicked = {}
+            ),
+            dismissButton = AlertConfirmAndDismissButton(
+                buttonText = application.getString(StringsIds.no),
+                onButtonClicked = {}
+            )
+        )
+    }
+
+    fun onDeleteShotClicked() = navigation.alert(alert = deleteShotAlert())
 }

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -520,32 +520,32 @@ class LogShotViewModel(
 
     suspend fun onYesDeleteShot() {
         navigation.enableProgress(progress = Progress())
-            currentPlayer?.let { player ->
-                playerRepository.updatePlayer(
-                    currentPlayer = player,
-                    newPlayer = player.copy(
-                        firstName = player.firstName,
-                        lastName = player.lastName,
-                        position = player.position,
-                        firebaseKey = player.firebaseKey,
-                        imageUrl = player.imageUrl,
-                        shotsLoggedList = filterShotsById(shots = player.shotsLoggedList)
-                    )
+        currentPlayer?.let { player ->
+            playerRepository.updatePlayer(
+                currentPlayer = player,
+                newPlayer = player.copy(
+                    firstName = player.firstName,
+                    lastName = player.lastName,
+                    position = player.position,
+                    firebaseKey = player.firebaseKey,
+                    imageUrl = player.imageUrl,
+                    shotsLoggedList = filterShotsById(shots = player.shotsLoggedList)
                 )
+            )
 
-                deleteFirebaseUserInfo.deleteShot(
-                    playerKey = player.firebaseKey,
-                    index = shotId - 1
-                ).collectLatest { hasDeleted ->
-                    if (hasDeleted) {
-                        navigateToCreateOrEditPlayer()
-                        navigation.alert(alert = deleteShotConfirmAlert())
-                    } else {
-                        navigation.disableProgress()
-                        navigation.alert(alert = deleteShotErrorAlert())
-                    }
+            deleteFirebaseUserInfo.deleteShot(
+                playerKey = player.firebaseKey,
+                index = shotId - 1
+            ).collectLatest { hasDeleted ->
+                if (hasDeleted) {
+                    navigateToCreateOrEditPlayer()
+                    navigation.alert(alert = deleteShotConfirmAlert())
+                } else {
+                    navigation.disableProgress()
+                    navigation.alert(alert = deleteShotErrorAlert())
                 }
-            } ?: navigation.disableProgress()
+            }
+        } ?: navigation.disableProgress()
     }
 
     fun deleteShotAlert(): Alert {

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreen.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreen.kt
@@ -1,3 +1,0 @@
-package com.nicholas.rutherford.track.your.shot.feature.players.shots.shotscreen
-
-class ShotScreen

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenNavigation.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenNavigation.kt
@@ -1,3 +1,0 @@
-package com.nicholas.rutherford.track.your.shot.feature.players.shots.shotscreen
-
-class ShotScreenNavigation

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenNavigationImpl.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenNavigationImpl.kt
@@ -1,3 +1,0 @@
-package com.nicholas.rutherford.track.your.shot.feature.players.shots.shotscreen
-
-class ShotScreenNavigationImpl

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenState.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenState.kt
@@ -1,3 +1,0 @@
-package com.nicholas.rutherford.track.your.shot.feature.players.shots.shotscreen
-
-class ShotScreenState

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/shotscreen/ShotScreenViewModel.kt
@@ -1,3 +1,0 @@
-package com.nicholas.rutherford.track.your.shot.feature.players.shots.shotscreen
-
-class ShotScreenViewModel

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -936,18 +936,22 @@ class LogShotViewModelTest {
 
             verify { navigation.enableProgress(progress = any()) }
             verify { navigation.disableProgress() }
-            verify(exactly = 0) { navigation.alert(alert = any())}
+            verify(exactly = 0) { navigation.alert(alert = any()) }
         }
 
         @Test
         fun `when edited player is not null and hasDeleted returns false should navigate to alert`() = runTest {
-            val currentPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
-                TestShotLogged.build().copy(id = 11),
-                TestShotLogged.build().copy(id = 22)
-            ))
-            val newPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
-                TestShotLogged.build().copy(id = 11)
-            ))
+            val currentPlayer = TestPlayer().create().copy(
+                shotsLoggedList = listOf(
+                    TestShotLogged.build().copy(id = 11),
+                    TestShotLogged.build().copy(id = 22)
+                )
+            )
+            val newPlayer = TestPlayer().create().copy(
+                shotsLoggedList = listOf(
+                    TestShotLogged.build().copy(id = 11)
+                )
+            )
 
             logShotViewModel.shotId = 22
             logShotViewModel.currentPlayer = currentPlayer
@@ -963,13 +967,17 @@ class LogShotViewModelTest {
 
         @Test
         fun `when edited player is not null and hasDeleted returns true should pop and navigate to alert`() = runTest {
-            val currentPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
-                TestShotLogged.build().copy(id = 11),
-                TestShotLogged.build().copy(id = 22)
-            ))
-            val newPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
-                TestShotLogged.build().copy(id = 11)
-            ))
+            val currentPlayer = TestPlayer().create().copy(
+                shotsLoggedList = listOf(
+                    TestShotLogged.build().copy(id = 11),
+                    TestShotLogged.build().copy(id = 22)
+                )
+            )
+            val newPlayer = TestPlayer().create().copy(
+                shotsLoggedList = listOf(
+                    TestShotLogged.build().copy(id = 11)
+                )
+            )
 
             logShotViewModel.shotId = 22
             logShotViewModel.isExistingPlayer = true
@@ -992,7 +1000,7 @@ class LogShotViewModelTest {
         val shotLoggedList = listOf(
             TestShotLogged.build().copy(id = 11),
             TestShotLogged.build().copy(id = 22),
-            TestShotLogged.build().copy(id = 2),
+            TestShotLogged.build().copy(id = 2)
         )
 
         logShotViewModel.shotId = shotId

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -14,15 +14,19 @@ import com.nicholas.rutherford.track.your.shot.data.test.room.TestPlayer
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestShotLogged
 import com.nicholas.rutherford.track.your.shot.feature.players.shots.logshot.pendingshot.CurrentPendingShot
 import com.nicholas.rutherford.track.your.shot.feature.players.shots.logshot.pendingshot.PendingShot
+import com.nicholas.rutherford.track.your.shot.firebase.core.delete.DeleteFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.helper.extensions.toDateValue
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
@@ -49,6 +53,8 @@ class LogShotViewModelTest {
     private val pendingPlayerRepository = mockk<PendingPlayerRepository>(relaxed = true)
     private val playerRepository = mockk<PlayerRepository>(relaxed = true)
 
+    private val deleteFirebaseUserInfo = mockk<DeleteFirebaseUserInfo>(relaxed = true)
+
     private val currentPendingShot = mockk<CurrentPendingShot>(relaxed = true)
 
     @BeforeEach
@@ -60,6 +66,7 @@ class LogShotViewModelTest {
             declaredShotRepository = declaredShotRepository,
             pendingPlayerRepository = pendingPlayerRepository,
             playerRepository = playerRepository,
+            deleteFirebaseUserInfo = deleteFirebaseUserInfo,
             currentPendingShot = currentPendingShot
         )
     }
@@ -609,7 +616,7 @@ class LogShotViewModelTest {
 
     @Nested
     inner class NoChangesForShotAlert {
-        val pendingShotLogged = TestShotLogged.build()
+        private val pendingShotLogged = TestShotLogged.build()
 
         @Test
         fun `when initialShotLogged is set to null should return null`() {
@@ -916,5 +923,136 @@ class LogShotViewModelTest {
         Assertions.assertEquals(logShotViewModel.logShotMutableStateFlow.value, LogShotState())
 
         verify { navigation.pop() }
+    }
+
+    @Nested
+    inner class OnYesDeleteShot {
+
+        @Test
+        fun `when edited player is set to null should not navigate to alert`() = runTest {
+            logShotViewModel.currentPlayer = null
+
+            logShotViewModel.onYesDeleteShot()
+
+            verify { navigation.enableProgress(progress = any()) }
+            verify { navigation.disableProgress() }
+            verify(exactly = 0) { navigation.alert(alert = any())}
+        }
+
+        @Test
+        fun `when edited player is not null and hasDeleted returns false should navigate to alert`() = runTest {
+            val currentPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
+                TestShotLogged.build().copy(id = 11),
+                TestShotLogged.build().copy(id = 22)
+            ))
+            val newPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
+                TestShotLogged.build().copy(id = 11)
+            ))
+
+            logShotViewModel.shotId = 22
+            logShotViewModel.currentPlayer = currentPlayer
+
+            coEvery { playerRepository.updatePlayer(currentPlayer = currentPlayer, newPlayer = newPlayer) } just runs
+            coEvery { deleteFirebaseUserInfo.deleteShot(playerKey = currentPlayer.firebaseKey, index = 21) } returns flowOf(value = false)
+
+            logShotViewModel.onYesDeleteShot()
+
+            verify { navigation.disableProgress() }
+            verify { navigation.alert(alert = any()) }
+        }
+
+        @Test
+        fun `when edited player is not null and hasDeleted returns true should pop and navigate to alert`() = runTest {
+            val currentPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
+                TestShotLogged.build().copy(id = 11),
+                TestShotLogged.build().copy(id = 22)
+            ))
+            val newPlayer = TestPlayer().create().copy(shotsLoggedList = listOf(
+                TestShotLogged.build().copy(id = 11)
+            ))
+
+            logShotViewModel.shotId = 22
+            logShotViewModel.isExistingPlayer = true
+            logShotViewModel.currentPlayer = currentPlayer
+
+            coEvery { playerRepository.updatePlayer(currentPlayer = currentPlayer, newPlayer = newPlayer) } just runs
+            coEvery { deleteFirebaseUserInfo.deleteShot(playerKey = currentPlayer.firebaseKey, index = 21) } returns flowOf(value = true)
+
+            logShotViewModel.onYesDeleteShot()
+
+            verify { navigation.disableProgress() }
+            verify { navigation.popToEditPlayer() }
+            verify { navigation.alert(alert = any()) }
+        }
+    }
+
+    @Test
+    fun `filter shots by id should filter out shots matching the local param shotId`() {
+        val shotId = 2
+        val shotLoggedList = listOf(
+            TestShotLogged.build().copy(id = 11),
+            TestShotLogged.build().copy(id = 22),
+            TestShotLogged.build().copy(id = 2),
+        )
+
+        logShotViewModel.shotId = shotId
+
+        val result = logShotViewModel.filterShotsById(shots = shotLoggedList)
+
+        Assertions.assertEquals(result, listOf(TestShotLogged.build().copy(id = 11), TestShotLogged.build().copy(id = 22)))
+    }
+
+    @Test
+    fun `delete shot alert`() {
+        logShotViewModel.logShotMutableStateFlow.value = LogShotState(shotName = "Hook Shot")
+
+        every { application.getString(StringsIds.deleteShot) } returns "Delete Shot"
+        every { application.getString(StringsIds.yes) } returns "Yes"
+        every { application.getString(StringsIds.no) } returns "No"
+        every { application.getString(StringsIds.areYouSureYouWantToDeleteXShot, "Hook Shot") } returns "Are you sure you want to delete Hook Shot?"
+
+        val result = logShotViewModel.deleteShotAlert()
+
+        Assertions.assertEquals(result.title, "Delete Shot")
+        Assertions.assertEquals(result.description, "Are you sure you want to delete Hook Shot?")
+        Assertions.assertEquals(result.confirmButton!!.buttonText, "Yes")
+        Assertions.assertEquals(result.dismissButton!!.buttonText, "No")
+    }
+
+    @Test
+    fun `delete shot confirm alert`() {
+        logShotViewModel.logShotMutableStateFlow.value = LogShotState(shotName = "Hook Shot")
+
+        every { application.getString(StringsIds.shotHasBeenDeleted) } returns "Shot Has Been Deleted"
+        every { application.getString(StringsIds.gotIt) } returns "Got It"
+        every { application.getString(StringsIds.xShotHasBeenRemovedDescription, "Hook Shot") } returns "Hook Shot has been removed from this player\'s shot history"
+
+        val result = logShotViewModel.deleteShotConfirmAlert()
+
+        Assertions.assertEquals(result.title, "Shot Has Been Deleted")
+        Assertions.assertEquals(result.description, "Hook Shot has been removed from this player's shot history")
+        Assertions.assertEquals(result.confirmButton!!.buttonText, "Got It")
+    }
+
+    @Test
+    fun `delete shot error alert`() {
+        logShotViewModel.logShotMutableStateFlow.value = LogShotState(shotName = "Hook Shot")
+
+        every { application.getString(StringsIds.shotHasNotBeenDeleted) } returns "Shot Has Not Been Deleted"
+        every { application.getString(StringsIds.gotIt) } returns "Got It"
+        every { application.getString(StringsIds.xShotHasNotBeenRemovedDescription, "Hook Shot") } returns "Hook Shot has not been removed from this player\'s shot history"
+
+        val result = logShotViewModel.deleteShotErrorAlert()
+
+        Assertions.assertEquals(result.title, "Shot Has Not Been Deleted")
+        Assertions.assertEquals(result.description, "Hook Shot has not been removed from this player's shot history")
+        Assertions.assertEquals(result.confirmButton!!.buttonText, "Got It")
+    }
+
+    @Test
+    fun `on delete shot clicked should call delete show alert on navigation`() {
+        logShotViewModel.onDeleteShotClicked()
+
+        verify { navigation.alert(alert = any()) }
     }
 }

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListViewModel.kt
@@ -3,7 +3,6 @@ package com.nicholas.rutherford.track.your.shot.feature.players.playerlist
 import android.app.Application
 import androidx.lifecycle.ViewModel
 import com.nicholas.rutherford.track.your.shot.base.resources.StringsIds
-import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
@@ -34,7 +33,6 @@ class PlayersListViewModel(
     private val network: Network,
     private val accountManager: AccountManager,
     private val deleteFirebaseUserInfo: DeleteFirebaseUserInfo,
-    private val activeUserRepository: ActiveUserRepository,
     private val playersAdditionUpdates: PlayersAdditionUpdates,
     private val playerRepository: PlayerRepository,
     private val pendingPlayerRepository: PendingPlayerRepository,
@@ -187,18 +185,6 @@ class PlayersListViewModel(
         return Alert(
             title = application.getString(StringsIds.notConnectedToInternet),
             description = application.getString(StringsIds.weHaveDetectedCurrentlyNotConnectedToInternetDescription),
-            dismissButton = AlertConfirmAndDismissButton(
-                buttonText = application.getString(
-                    StringsIds.gotIt
-                )
-            )
-        )
-    }
-
-    private fun weHaveDetectedAProblemWithYourAccountAlert(): Alert {
-        return Alert(
-            title = application.getString(StringsIds.empty),
-            description = application.getString(StringsIds.weHaveDetectedAProblemWithYourAccountPleaseContactSupportToResolveIssue),
             dismissButton = AlertConfirmAndDismissButton(
                 buttonText = application.getString(
                     StringsIds.gotIt

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
@@ -2,7 +2,6 @@ package com.nicholas.rutherford.track.your.shot.players.playerlist
 
 import android.app.Application
 import com.nicholas.rutherford.track.your.shot.base.resources.StringsIds
-import com.nicholas.rutherford.track.your.shot.data.room.repository.ActiveUserRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PendingPlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.repository.PlayerRepository
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
@@ -56,7 +55,6 @@ class PlayersListViewModelTest {
     private val accountManager = mockk<AccountManager>(relaxed = true)
 
     private val deleteFirebaseUserInfo = mockk<DeleteFirebaseUserInfo>(relaxed = true)
-    private val activeUserRepository = mockk<ActiveUserRepository>(relaxed = true)
 
     private val playersAdditionUpdates = mockk<PlayersAdditionUpdates>(relaxed = true)
 
@@ -79,7 +77,6 @@ class PlayersListViewModelTest {
             network = network,
             accountManager = accountManager,
             deleteFirebaseUserInfo = deleteFirebaseUserInfo,
-            activeUserRepository = activeUserRepository,
             playersAdditionUpdates = playersAdditionUpdates,
             playerRepository = playerRepository,
             pendingPlayerRepository = pendingPlayerRepository,
@@ -172,7 +169,6 @@ class PlayersListViewModelTest {
                 network = network,
                 accountManager = accountManager,
                 deleteFirebaseUserInfo = deleteFirebaseUserInfo,
-                activeUserRepository = activeUserRepository,
                 playersAdditionUpdates = playersAdditionUpdates,
                 playerRepository = playerRepository,
                 pendingPlayerRepository = pendingPlayerRepository,
@@ -211,7 +207,6 @@ class PlayersListViewModelTest {
                 network = network,
                 accountManager = accountManager,
                 deleteFirebaseUserInfo = deleteFirebaseUserInfo,
-                activeUserRepository = activeUserRepository,
                 playersAdditionUpdates = playersAdditionUpdates,
                 playerRepository = playerRepository,
                 createSharedPreferences = createSharedPreferences,
@@ -251,7 +246,6 @@ class PlayersListViewModelTest {
                 network = network,
                 accountManager = accountManager,
                 deleteFirebaseUserInfo = deleteFirebaseUserInfo,
-                activeUserRepository = activeUserRepository,
                 playersAdditionUpdates = playersAdditionUpdates,
                 playerRepository = playerRepository,
                 createSharedPreferences = createSharedPreferences,

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfo.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfo.kt
@@ -4,4 +4,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface DeleteFirebaseUserInfo {
     fun deletePlayer(playerKey: String): Flow<Boolean>
+    fun deleteShot(playerKey: String, index: Int): Flow<Boolean>
 }

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfo.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfo.kt
@@ -3,6 +3,9 @@ package com.nicholas.rutherford.track.your.shot.firebase.core.delete
 import kotlinx.coroutines.flow.Flow
 
 interface DeleteFirebaseUserInfo {
+    val hasDeletedShotFlow: Flow<Boolean>
+
+    fun updateHasDeletedShotFlow(hasDeletedShot: Boolean)
     fun deletePlayer(playerKey: String): Flow<Boolean>
     fun deleteShot(playerKey: String, index: Int): Flow<Boolean>
 }

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfoImpl.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfoImpl.kt
@@ -5,6 +5,8 @@ import com.google.firebase.database.FirebaseDatabase
 import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import timber.log.Timber
 
@@ -12,6 +14,13 @@ class DeleteFirebaseUserInfoImpl(
     private val firebaseAuth: FirebaseAuth,
     private val firebaseDatabase: FirebaseDatabase
 ) : DeleteFirebaseUserInfo {
+
+    internal val hasDeletedShotMutableStateFlow: MutableStateFlow<Boolean> = MutableStateFlow(value = false)
+    override val hasDeletedShotFlow: Flow<Boolean> = hasDeletedShotMutableStateFlow.asStateFlow()
+
+    override fun updateHasDeletedShotFlow(hasDeletedShot: Boolean) {
+        hasDeletedShotMutableStateFlow.value = hasDeletedShot
+    }
 
     override fun deletePlayer(playerKey: String): Flow<Boolean> {
         return callbackFlow {
@@ -23,6 +32,9 @@ class DeleteFirebaseUserInfoImpl(
                 .addOnCompleteListener { task ->
                     if (task.isSuccessful) {
                         trySend(element = true)
+                    } else {
+                        Timber.w(message = "Error(deletePlayer) -> Was not able to delete current player from given account.")
+                        trySend(element = false)
                     }
                 }
                 .addOnFailureListener { exception ->
@@ -36,16 +48,22 @@ class DeleteFirebaseUserInfoImpl(
     override fun deleteShot(playerKey: String, index: Int): Flow<Boolean> {
         return callbackFlow {
             val uid = firebaseAuth.currentUser?.uid ?: ""
-            val path = "${Constants.USERS}/$uid/${Constants.PLAYERS}/$playerKey/shotsLogged/$index"
+            val path = "${Constants.USERS}/$uid/${Constants.PLAYERS}/$playerKey/${Constants.SHOTS_LOGGED}/$index"
 
             firebaseDatabase.getReference(path)
                 .removeValue()
                 .addOnCompleteListener { task ->
                     if (task.isSuccessful) {
+                        hasDeletedShotMutableStateFlow.value = true
                         trySend(element = true)
+                    } else {
+                        hasDeletedShotMutableStateFlow.value = false
+                        Timber.w(message = "Error(deletePlayer) -> Was not able to delete current player shot from given account.")
+                        trySend(element = false)
                     }
                 }
                 .addOnFailureListener { exception ->
+                    hasDeletedShotMutableStateFlow.value = false
                     Timber.e(message = "Error(deletePlayer) -> Was not able to delete current player shot from given account. With following stack trace $exception")
                     trySend(element = false)
                 }

--- a/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfoImpl.kt
+++ b/firebase/core/src/main/java/com/nicholas/rutherford/track/your/shot/firebase/core/delete/DeleteFirebaseUserInfoImpl.kt
@@ -32,4 +32,24 @@ class DeleteFirebaseUserInfoImpl(
             awaitClose()
         }
     }
+
+    override fun deleteShot(playerKey: String, index: Int): Flow<Boolean> {
+        return callbackFlow {
+            val uid = firebaseAuth.currentUser?.uid ?: ""
+            val path = "${Constants.USERS}/$uid/${Constants.PLAYERS}/$playerKey/shotsLogged/$index"
+
+            firebaseDatabase.getReference(path)
+                .removeValue()
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        trySend(element = true)
+                    }
+                }
+                .addOnFailureListener { exception ->
+                    Timber.e(message = "Error(deletePlayer) -> Was not able to delete current player shot from given account. With following stack trace $exception")
+                    trySend(element = false)
+                }
+            awaitClose()
+        }
+    }
 }

--- a/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationDestinationsWithParams.kt
+++ b/navigation/src/main/java/com/nicholas/rutherford/track/your/shot/navigation/NavigationDestinationsWithParams.kt
@@ -20,7 +20,9 @@ object NavigationDestinationsWithParams {
         shotId: Int,
         viewCurrentExistingShot: Boolean,
         viewCurrentPendingShot: Boolean
-    ): String = "${NavigationDestinations.LOG_SHOT_SCREEN}/$isExistingPlayer/$playerId/$shotType/$shotId/$viewCurrentExistingShot/$viewCurrentPendingShot"
+    ): String {
+        return "${NavigationDestinations.LOG_SHOT_SCREEN}/$isExistingPlayer/$playerId/$shotType/$shotId/$viewCurrentExistingShot/$viewCurrentPendingShot"
+    }
 
     fun termsConditionsWithParams(
         isAcknowledgeConditions: Boolean


### PR DESCRIPTION
### Trello
- https://trello.com/c/X80xCDBq/189-introduce-some-type-of-manager-class-to-help-with-createeditplayerviewmodel

### Issues
- Currently the user did not have the ability to delete there given shots on there given account. We should be adding CRUD functionality for the user(Create, Read, Update, and Delete) a given shots logged by the user. 

### Proposed Changes
- Add functionality that will search by a id to allow a user to delete there given shot and then update given UI. 

### TO-DO
- N/A 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 