### PR TITLE
nick: Bug - User should not be able to move forward with logging a shot if they don't enter valid shots made or misses

### DIFF
--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
@@ -56,7 +56,6 @@ object StringsIds {
         R.string.device_is_currently_not_connected_to_internet_desc
     val doYouWishToProceedDescription =
         R.string.do_you_wish_to_proceed_description
-
     val emailHasBeenSentToRestPasswordPleaseFollowDirectionsToResetPassword =
         R.string.email_has_been_sent_to_reset_password_please_follow_directions_to_reset_password
     val emailHasBeenSentToVerifyAccountPleaseOpenEmailSentEmailToVerifyAccount =
@@ -99,6 +98,8 @@ object StringsIds {
     val hintLogNewShots = R.string.hint_log_new_shots
     val hintLogNewShotsForPlayer = R.string.hint_log_new_shots_for_player
     val introduction = R.string.introduction
+    val invalidShotInput = R.string.invalid_shot_input
+    val invalidShotInputDescription = R.string.invalid_shot_input_description
     val issueOccurred = R.string.issue_occurred
     val lastName = R.string.last_name
     val leavingTheAppWillResultInYouNotFinishingTheAccountCreationProcessDescription =

--- a/base-resources/src/main/res/values/strings.xml
+++ b/base-resources/src/main/res/values/strings.xml
@@ -89,6 +89,8 @@
     <string name="hint_log_new_shots">Press the "Log Shots" button to record shots for the player.</string>
     <string name="hint_log_new_shots_for_player">Press the "Log Shots" button to record shots for</string>
     <string name="introduction">Introduction</string>
+    <string name="invalid_shot_input">Invalid Shot Input</string>
+    <string name="invalid_shot_input_description">Shots logged must be whole numbers. Please enter a whole number to log valid shots made or missed.</string>
     <string name="issue_occurred">Issue Occurred</string>
     <string name="last_name">Last Name</string>
     <string name="leaving_the_app_will_result_you_in_not_finishing_the_account_creation_process_description">Leaving the app will result you in not finishing the account creation process. You will not be able to continue until you verify your email. If you verify your email and then come back to the app, you can continue to create your account.</string>

--- a/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
+++ b/feature/players/shots/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModel.kt
@@ -252,7 +252,23 @@ class LogShotViewModel(
         }
     }
 
-    internal fun updateStateAfterShotsMadeInput(shots: Int) {
+    internal fun onConfirmShotsMadeClicked(shotsValue: String) {
+        if (shotsValue.isNotEmpty()) {
+            shotsValue.toIntOrNull()?.let { shots ->
+                updateShotsMadeState(shots = shots)
+            } ?: navigation.alert(alert = invalidShotInputAlert())
+        }
+    }
+
+    internal fun onConfirmShotsMissedClicked(shotsValue: String) {
+        if (shotsValue.isNotEmpty()) {
+            shotsValue.toIntOrNull()?.let { shots ->
+                updateShotsMissedState(shots = shots)
+            } ?: navigation.alert(alert = invalidShotInputAlert())
+        }
+    }
+
+    internal fun updateShotsMadeState(shots: Int) {
         logShotMutableStateFlow.update { state ->
             state.copy(
                 shotsMade = shots,
@@ -306,11 +322,7 @@ class LogShotViewModel(
                 dismissButtonResId = StringsIds.cancel,
                 placeholderResId = StringsIds.shotsMade,
                 startingInputAmount = startingInputAmount(amount = logShotMutableStateFlow.value.shotsMade),
-                onConfirmButtonClicked = { shots ->
-                    if (shots.isNotEmpty()) {
-                        updateStateAfterShotsMadeInput(shots = shots.toInt())
-                    }
-                }
+                onConfirmButtonClicked = { shotsValue -> onConfirmShotsMadeClicked(shotsValue = shotsValue) }
             )
         )
     }
@@ -323,23 +335,15 @@ class LogShotViewModel(
                 dismissButtonResId = StringsIds.cancel,
                 placeholderResId = StringsIds.shotsMissed,
                 startingInputAmount = startingInputAmount(amount = logShotMutableStateFlow.value.shotsMissed),
-                onConfirmButtonClicked = { shots ->
-                    if (shots.isNotEmpty()) {
-                        updateShotsMissedState(shots = shots.toInt())
-                    }
-                }
+                onConfirmButtonClicked = { shotsValue -> onConfirmShotsMissedClicked(shotsValue = shotsValue) }
             )
         )
     }
 
     fun invalidLogShotAlert(description: String): Alert {
         return Alert(
-            title = application.getString(StringsIds.empty),
-            dismissButton = AlertConfirmAndDismissButton(
-                buttonText = application.getString(
-                    StringsIds.gotIt
-                )
-            ),
+            title = application.getString(StringsIds.error),
+            dismissButton = AlertConfirmAndDismissButton(buttonText = application.getString(StringsIds.gotIt)),
             description = description
         )
     }
@@ -560,6 +564,14 @@ class LogShotViewModel(
                 buttonText = application.getString(StringsIds.no),
                 onButtonClicked = {}
             )
+        )
+    }
+
+    fun invalidShotInputAlert(): Alert {
+        return Alert(
+            title = application.getString(StringsIds.invalidShotInput),
+            description = application.getString(StringsIds.invalidShotInputDescription),
+            confirmButton = AlertConfirmAndDismissButton(buttonText = application.getString(StringsIds.gotIt))
         )
     }
 

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -405,10 +405,10 @@ class LogShotViewModelTest {
     }
 
     @Test
-    fun `update state after shots made input should update state`() {
+    fun `update shots after made state should update state`() {
         val shots = 2
 
-        logShotViewModel.updateStateAfterShotsMadeInput(shots = shots)
+        logShotViewModel.updateShotsMadeState(shots = shots)
 
         val state = logShotViewModel.logShotMutableStateFlow.value
         Assertions.assertEquals(
@@ -468,6 +468,110 @@ class LogShotViewModelTest {
     }
 
     @Nested
+    inner class OnConfirmShotsMadeClicked {
+
+        @Test
+        fun `when passed in shots value is empty should not update state or call alert`() {
+            logShotViewModel.onConfirmShotsMadeClicked(shotsValue = "")
+
+            val state = logShotViewModel.logShotMutableStateFlow.value
+            Assertions.assertEquals(
+                state,
+                LogShotState()
+            )
+
+            verify(exactly = 0) { navigation.alert(alert = any())}
+        }
+
+        @Test
+        fun `when passed in shots value is a invalid int should not update state and call alert`() {
+            logShotViewModel.onConfirmShotsMadeClicked(shotsValue = "22.111")
+
+            val state = logShotViewModel.logShotMutableStateFlow.value
+            Assertions.assertEquals(
+                state,
+                LogShotState()
+            )
+
+            verify(exactly = 1) { navigation.alert(alert = any())}
+        }
+
+        @Test
+        fun `when passed in shots value is a valid int should update state and not call alert`() {
+            logShotViewModel.onConfirmShotsMadeClicked(shotsValue = "2")
+
+            val state = logShotViewModel.logShotMutableStateFlow.value
+            Assertions.assertEquals(
+                state,
+                LogShotState(
+                    shotName = "",
+                    playerName = "",
+                    shotsLoggedDateValue = "",
+                    shotsTakenDateValue = "",
+                    shotsMade = 2,
+                    shotsAttempted = 2,
+                    shotsMadePercentValue = "",
+                    shotsMissedPercentValue = ""
+                )
+            )
+
+            verify(exactly = 0) { navigation.alert(alert = any())}
+        }
+    }
+
+    @Nested
+    inner class OnConfirmShotsMissedClicked {
+
+        @Test
+        fun `when passed in shots value is empty should not update state or call alert`() {
+            logShotViewModel.onConfirmShotsMissedClicked(shotsValue = "")
+
+            val state = logShotViewModel.logShotMutableStateFlow.value
+            Assertions.assertEquals(
+                state,
+                LogShotState()
+            )
+
+            verify(exactly = 0) { navigation.alert(alert = any())}
+        }
+
+        @Test
+        fun `when passed in shots value is a invalid int should not update state and call alert`() {
+            logShotViewModel.onConfirmShotsMissedClicked(shotsValue = "22.111")
+
+            val state = logShotViewModel.logShotMutableStateFlow.value
+            Assertions.assertEquals(
+                state,
+                LogShotState()
+            )
+
+            verify(exactly = 1) { navigation.alert(alert = any())}
+        }
+
+        @Test
+        fun `when passed in shots value is a valid int should update state and not call alert`() {
+            logShotViewModel.onConfirmShotsMissedClicked(shotsValue = "2")
+
+            val state = logShotViewModel.logShotMutableStateFlow.value
+            Assertions.assertEquals(
+                state,
+                LogShotState(
+                    shotName = "",
+                    playerName = "",
+                    shotsLoggedDateValue = "",
+                    shotsTakenDateValue = "",
+                    shotsMissed = 2,
+                    shotsAttempted = 2,
+                    shotsMadePercentValue = "",
+                    shotsMissedPercentValue = ""
+                )
+            )
+
+            verify(exactly = 0) { navigation.alert(alert = any())}
+        }
+    }
+
+    @Nested
     inner class StartingInputAmount {
 
         @Test
@@ -505,13 +609,13 @@ class LogShotViewModelTest {
     fun `invalid shot alert should return alert`() {
         val description = "description"
 
-        every { application.getString(StringsIds.empty) } returns ""
+        every { application.getString(StringsIds.error) } returns "Error"
         every { application.getString(StringsIds.gotIt) } returns "Got It"
 
         Assertions.assertEquals(
             logShotViewModel.invalidLogShotAlert(description = description),
             Alert(
-                title = "",
+                title = "Error",
                 dismissButton = AlertConfirmAndDismissButton(buttonText = "Got It"),
                 description = description
             )
@@ -1025,6 +1129,19 @@ class LogShotViewModelTest {
         Assertions.assertEquals(result.description, "Are you sure you want to delete Hook Shot?")
         Assertions.assertEquals(result.confirmButton!!.buttonText, "Yes")
         Assertions.assertEquals(result.dismissButton!!.buttonText, "No")
+    }
+
+    @Test
+    fun `invalid shot input alert`() {
+        every { application.getString(StringsIds.invalidShotInput) } returns "Invalid Shot Input"
+        every { application.getString(StringsIds.invalidShotInputDescription) } returns "Shots logged must be whole numbers. Please enter a whole number to log valid shots made or missed."
+        every { application.getString(StringsIds.gotIt) } returns "Got It"
+
+        val result = logShotViewModel.invalidShotInputAlert()
+
+        Assertions.assertEquals(result.title, "Invalid Shot Input")
+        Assertions.assertEquals(result.description, "Shots logged must be whole numbers. Please enter a whole number to log valid shots made or missed.")
+        Assertions.assertEquals(result.confirmButton!!.buttonText, "Got It")
     }
 
     @Test

--- a/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
+++ b/feature/players/shots/src/test/java/com/nicholas/rutherford/track/your/shot/feature/players/shots/logshot/LogShotViewModelTest.kt
@@ -480,7 +480,7 @@ class LogShotViewModelTest {
                 LogShotState()
             )
 
-            verify(exactly = 0) { navigation.alert(alert = any())}
+            verify(exactly = 0) { navigation.alert(alert = any()) }
         }
 
         @Test
@@ -493,7 +493,7 @@ class LogShotViewModelTest {
                 LogShotState()
             )
 
-            verify(exactly = 1) { navigation.alert(alert = any())}
+            verify(exactly = 1) { navigation.alert(alert = any()) }
         }
 
         @Test
@@ -515,7 +515,7 @@ class LogShotViewModelTest {
                 )
             )
 
-            verify(exactly = 0) { navigation.alert(alert = any())}
+            verify(exactly = 0) { navigation.alert(alert = any()) }
         }
     }
 
@@ -532,7 +532,7 @@ class LogShotViewModelTest {
                 LogShotState()
             )
 
-            verify(exactly = 0) { navigation.alert(alert = any())}
+            verify(exactly = 0) { navigation.alert(alert = any()) }
         }
 
         @Test
@@ -545,7 +545,7 @@ class LogShotViewModelTest {
                 LogShotState()
             )
 
-            verify(exactly = 1) { navigation.alert(alert = any())}
+            verify(exactly = 1) { navigation.alert(alert = any()) }
         }
 
         @Test
@@ -567,7 +567,7 @@ class LogShotViewModelTest {
                 )
             )
 
-            verify(exactly = 0) { navigation.alert(alert = any())}
+            verify(exactly = 0) { navigation.alert(alert = any()) }
         }
     }
 


### PR DESCRIPTION
### Trello
https://trello.com/c/zgWLWB69/222-bug-user-should-not-be-able-to-move-forward-with-logging-a-shot-if-they-dont-enter-valid-shots-made-or-misses

### Issues
- Currently in the app when the user enters shot made and misses, the number keypad pops up tot he user. They have the ability to enter decimal points which we don’t take. Currently if the user enters a decimal or invalid non whole number, the app crashes because it doesn’t know how to do the actual calculation.
- Noticed for an error alert for the log shot flow we were displaying an empty string for a title. It should display as Error. 

### Proposed Changes
- Before we do any type of calculation read if the number is actually a valid number. If it is move forward with the intended process if not, then show some invalid state to the user.
- Fix the alert title 
- Add unit tests

### TO-DO
- N/A 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 