### PR TITLE
nick: Up version name for new release to Google Play Console 

### DIFF
--- a/buildSrc/src/main/kotlin/ConfigurationData.kt
+++ b/buildSrc/src/main/kotlin/ConfigurationData.kt
@@ -8,5 +8,5 @@ object ConfigurationData {
     const val testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     const val targetSdk = 34
     const val versionCode = 25
-    const val versionName = "1.0"
+    const val versionName = "1.1"
 }


### PR DESCRIPTION
### Trello
- N/A 

### Issues
- We need to up the versionName for the release to be `1.1`. The versionCode was already updated, but we should be updating the name for the new release. 

### Proposed Changes
- Update the new version name to be from 1.0 to 1.1, for the new release. 

### TO-DO
- N/A 

### Additional Info
- N/A 

### Screenshots / Videos 
- N/A 