### PR TITLE
nick: Removing collecting from Flows from the AccountManager

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/AppModule.kt
@@ -331,13 +331,10 @@ class AppModule {
                 scope = defaultCoroutineScope,
                 navigation = get(),
                 network = get(),
-                accountManager = get(),
                 deleteFirebaseUserInfo = get(),
                 dataAdditionUpdates = get(),
                 playerRepository = get(),
-                pendingPlayerRepository = get(),
-                createSharedPreferences = get(),
-                readSharedPreferences = get()
+                pendingPlayerRepository = get()
             )
         }
         viewModel {
@@ -362,11 +359,8 @@ class AppModule {
                 scope = defaultCoroutineScope,
                 navigation = get(),
                 declaredShotRepository = get(),
-                accountManager = get(),
                 playerRepository = get(),
-                pendingPlayerRepository = get(),
-                createSharedPreferences = get(),
-                readSharedPreferences = get()
+                pendingPlayerRepository = get()
             )
         }
         viewModel {
@@ -409,7 +403,6 @@ class AppModule {
                 activeUserRepository = get(),
                 createSharedPreferences = get(),
                 declaredShotRepository = get(),
-                accountManager = get(),
                 scope = defaultCoroutineScope
             )
         }

--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
@@ -220,6 +220,8 @@ fun NavigationComponent(
         return when {
             destination.contains(NavigationDestinations.REPORTS_LIST_SCREEN) -> reportListViewModel
             destination.contains(NavigationDestinations.CREATE_REPORT_SCREEN) -> createReportViewModel
+            destination.contains(NavigationDestinations.PLAYERS_LIST_SCREEN) -> playersListViewModel
+            destination.contains(NavigationDestinations.SELECT_SHOT_SCREEN) -> selectShotViewModel
             else -> null
         }
     }

--- a/base/vm/src/main/java/com/nicholas/rutherford/track/your/shot/base/vm/BaseViewModel.kt
+++ b/base/vm/src/main/java/com/nicholas/rutherford/track/your/shot/base/vm/BaseViewModel.kt
@@ -3,6 +3,5 @@ package com.nicholas.rutherford.track.your.shot.base.vm
 import androidx.lifecycle.ViewModel
 
 abstract class BaseViewModel : ViewModel() {
-    open fun onNavigatedTo() {
-    }
+    open fun onNavigatedTo() {}
 }

--- a/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/authentication/AuthenticationViewModel.kt
+++ b/feature/create-account/src/main/java/com/nicholas/rutherford/track/your/shot/feature/create/account/authentication/AuthenticationViewModel.kt
@@ -12,7 +12,6 @@ import com.nicholas.rutherford.track.your.shot.data.shared.progress.Progress
 import com.nicholas.rutherford.track.your.shot.firebase.core.create.CreateFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.firebase.util.authentication.AuthenticationFirebase
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import com.nicholas.rutherford.track.your.shot.helper.extensions.safeLet
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
@@ -29,7 +28,6 @@ class AuthenticationViewModel(
     private val activeUserRepository: ActiveUserRepository,
     private val createSharedPreferences: CreateSharedPreferences,
     private val declaredShotRepository: DeclaredShotRepository,
-    private val accountManager: AccountManager,
     private val scope: CoroutineScope
 ) : ViewModel() {
 
@@ -110,7 +108,6 @@ class AuthenticationViewModel(
                             createSharedPreferences.createShouldUpdateLoggedInDeclaredShotListPreference(value = true)
                             createSharedPreferences.createHasAuthenticatedAccount(value = true)
                             declaredShotRepository.createDeclaredShots()
-                            accountManager.updateLoggedInDeclaredShotFlow(declaredShots = declaredShotRepository.fetchAllDeclaredShots())
                             navigation.disableProgress()
                             navigation.navigateToTermsAndConditions()
                         } else {

--- a/feature/create-account/src/test/java/com/nicholas/rutherford/track/your/shot/feature/create/account/authentication/AuthenticationViewModelTest.kt
+++ b/feature/create-account/src/test/java/com/nicholas/rutherford/track/your/shot/feature/create/account/authentication/AuthenticationViewModelTest.kt
@@ -10,10 +10,13 @@ import com.nicholas.rutherford.track.your.shot.firebase.TestAuthenticateUserViaE
 import com.nicholas.rutherford.track.your.shot.firebase.core.create.CreateFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.firebase.core.read.ReadFirebaseUserInfo
 import com.nicholas.rutherford.track.your.shot.firebase.util.authentication.AuthenticationFirebase
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.helper.constants.Constants
 import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
-import io.mockk.*
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,7 +51,6 @@ class AuthenticationViewModelTest {
     internal val createSharedPreferences = mockk<CreateSharedPreferences>(relaxed = true)
 
     internal val declaredShotRepository = mockk<DeclaredShotRepository>(relaxed = true)
-    internal val accountManager = mockk<AccountManager>(relaxed = true)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -76,7 +78,6 @@ class AuthenticationViewModelTest {
             activeUserRepository = activeUserRepository,
             createSharedPreferences = createSharedPreferences,
             declaredShotRepository = declaredShotRepository,
-            accountManager = accountManager,
             scope = scope
         )
     }
@@ -183,7 +184,6 @@ class AuthenticationViewModelTest {
                 activeUserRepository = activeUserRepository,
                 createSharedPreferences = createSharedPreferences,
                 declaredShotRepository = declaredShotRepository,
-                accountManager = accountManager,
                 scope = scope
             )
 
@@ -213,7 +213,6 @@ class AuthenticationViewModelTest {
                 activeUserRepository = activeUserRepository,
                 createSharedPreferences = createSharedPreferences,
                 declaredShotRepository = declaredShotRepository,
-                accountManager = accountManager,
                 scope = scope
             )
 
@@ -300,7 +299,6 @@ class AuthenticationViewModelTest {
                 activeUserRepository = activeUserRepository,
                 createSharedPreferences = createSharedPreferences,
                 declaredShotRepository = declaredShotRepository,
-                accountManager = accountManager,
                 scope = scope
             )
 
@@ -330,7 +328,6 @@ class AuthenticationViewModelTest {
                 activeUserRepository = activeUserRepository,
                 createSharedPreferences = createSharedPreferences,
                 declaredShotRepository = declaredShotRepository,
-                accountManager = accountManager,
                 scope = scope
             )
 

--- a/feature/players/build.gradle.kts
+++ b/feature/players/build.gradle.kts
@@ -67,6 +67,7 @@ android {
 }
 
 dependencies {
+    api(project(path = ":base:vm"))
     api(project(path = ":compose:components"))
     api(project(path = ":data:room"))
     api(project(path = ":feature:players:shots"))

--- a/feature/players/shots/build.gradle.kts
+++ b/feature/players/shots/build.gradle.kts
@@ -67,6 +67,7 @@ android {
 }
 
 dependencies {
+    api(project(path = ":base:vm"))
     api(project(path = ":compose:components"))
     api(project(path = ":data:room"))
     api(project(path = ":helper:account"))

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
@@ -13,11 +13,8 @@ import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.Player
 import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.PlayersListState
 import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.PlayersListViewModel
 import com.nicholas.rutherford.track.your.shot.firebase.core.delete.DeleteFirebaseUserInfo
-import com.nicholas.rutherford.track.your.shot.helper.account.AccountManager
 import com.nicholas.rutherford.track.your.shot.helper.extensions.dataadditionupdates.DataAdditionUpdates
 import com.nicholas.rutherford.track.your.shot.helper.network.Network
-import com.nicholas.rutherford.track.your.shot.shared.preference.create.CreateSharedPreferences
-import com.nicholas.rutherford.track.your.shot.shared.preference.read.ReadSharedPreferences
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -27,7 +24,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -52,17 +48,12 @@ class PlayersListViewModelTest {
 
     private val network = mockk<Network>(relaxed = true)
 
-    private val accountManager = mockk<AccountManager>(relaxed = true)
-
     private val deleteFirebaseUserInfo = mockk<DeleteFirebaseUserInfo>(relaxed = true)
 
     private val dataAdditionUpdates = mockk<DataAdditionUpdates>(relaxed = true)
 
     private val playerRepository = mockk<PlayerRepository>(relaxed = true)
     private val pendingPlayerRepository = mockk<PendingPlayerRepository>(relaxed = true)
-
-    private val createSharedPreferences = mockk<CreateSharedPreferences>(relaxed = true)
-    private val readSharedPreferences = mockk<ReadSharedPreferences>(relaxed = true)
 
     val player = TestPlayer().create()
 
@@ -75,13 +66,10 @@ class PlayersListViewModelTest {
             scope = scope,
             navigation = navigation,
             network = network,
-            accountManager = accountManager,
             deleteFirebaseUserInfo = deleteFirebaseUserInfo,
             dataAdditionUpdates = dataAdditionUpdates,
             playerRepository = playerRepository,
-            pendingPlayerRepository = pendingPlayerRepository,
-            createSharedPreferences = createSharedPreferences,
-            readSharedPreferences = readSharedPreferences
+            pendingPlayerRepository = pendingPlayerRepository
         )
     }
 
@@ -140,118 +128,6 @@ class PlayersListViewModelTest {
             every { dataAdditionUpdates.newPlayerHasBeenAddedSharedFlow } returns newPlayerHasBeenAddedSharedFlow
 
             playersListViewModel.collectPlayerAdditionUpdates()
-
-            Assertions.assertEquals(
-                playersListViewModel.playerListMutableStateFlow.value,
-                PlayersListState(playerList = playerList)
-            )
-            Assertions.assertEquals(
-                playersListViewModel.currentPlayerArrayList.toList(),
-                playerList
-            )
-        }
-    }
-
-    @Nested
-    inner class CollectLoggedInPlayerListStateFlow {
-
-        @Test
-        fun `when loggedInPlayerListStateFlow emits a empty list should not update state or list`() = runTest {
-            val playerList: List<Player> = emptyList()
-
-            every { accountManager.loggedInPlayerListStateFlow } returns MutableStateFlow(playerList)
-            every { readSharedPreferences.shouldUpdateLoggedInPlayerListState() } returns true
-
-            playersListViewModel = PlayersListViewModel(
-                application = application,
-                scope = scope,
-                navigation = navigation,
-                network = network,
-                accountManager = accountManager,
-                deleteFirebaseUserInfo = deleteFirebaseUserInfo,
-                dataAdditionUpdates = dataAdditionUpdates,
-                playerRepository = playerRepository,
-                pendingPlayerRepository = pendingPlayerRepository,
-                createSharedPreferences = createSharedPreferences,
-                readSharedPreferences = readSharedPreferences
-            )
-
-            Assertions.assertEquals(
-                playersListViewModel.playerListMutableStateFlow.value,
-                PlayersListState(playerList = playerList)
-            )
-            Assertions.assertEquals(
-                playersListViewModel.currentPlayerArrayList.toList(),
-                playerList
-            )
-        }
-
-        @Test
-        fun `when loggedInPlayerListStateFlow emits a list and shouldUpdateLoggedInPlayerListState is set to false should not update state and list`() = runTest {
-            val player = Player(
-                firstName = "first1",
-                lastName = "last1",
-                position = PlayerPositions.Center,
-                firebaseKey = "key",
-                imageUrl = "url",
-                shotsLoggedList = emptyList()
-            )
-
-            every { accountManager.loggedInPlayerListStateFlow } returns MutableStateFlow(listOf(player))
-            every { readSharedPreferences.shouldUpdateLoggedInPlayerListState() } returns false
-
-            playersListViewModel = PlayersListViewModel(
-                application = application,
-                scope = scope,
-                navigation = navigation,
-                network = network,
-                accountManager = accountManager,
-                deleteFirebaseUserInfo = deleteFirebaseUserInfo,
-                dataAdditionUpdates = dataAdditionUpdates,
-                playerRepository = playerRepository,
-                createSharedPreferences = createSharedPreferences,
-                pendingPlayerRepository = pendingPlayerRepository,
-                readSharedPreferences = readSharedPreferences
-            )
-
-            Assertions.assertEquals(
-                playersListViewModel.playerListMutableStateFlow.value,
-                PlayersListState(playerList = emptyPlayerList)
-            )
-            Assertions.assertEquals(
-                playersListViewModel.currentPlayerArrayList.toList(),
-                emptyPlayerList
-            )
-        }
-
-        @Test
-        fun `when loggedInPlayerListStateFlow emits a list and shouldUpdateLoggedInPlayerListState is set to true should update update state and list`() = runTest {
-            val player = Player(
-                firstName = "first1",
-                lastName = "last1",
-                position = PlayerPositions.Center,
-                firebaseKey = "key",
-                imageUrl = "url",
-                shotsLoggedList = emptyList()
-            )
-            val playerList = listOf(player)
-
-            every { accountManager.loggedInPlayerListStateFlow } returns MutableStateFlow(playerList)
-            every { readSharedPreferences.shouldUpdateLoggedInPlayerListState() } returns true
-
-            playersListViewModel = PlayersListViewModel(
-                application = application,
-                scope = scope,
-                navigation = navigation,
-                network = network,
-                accountManager = accountManager,
-                deleteFirebaseUserInfo = deleteFirebaseUserInfo,
-                dataAdditionUpdates = dataAdditionUpdates,
-                playerRepository = playerRepository,
-                createSharedPreferences = createSharedPreferences,
-                pendingPlayerRepository = pendingPlayerRepository,
-                readSharedPreferences = readSharedPreferences
-            )
 
             Assertions.assertEquals(
                 playersListViewModel.playerListMutableStateFlow.value,

--- a/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManager.kt
+++ b/helper/account/src/main/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManager.kt
@@ -1,19 +1,12 @@
 package com.nicholas.rutherford.track.your.shot.helper.account
 
-import com.nicholas.rutherford.track.your.shot.data.room.response.DeclaredShot
-import com.nicholas.rutherford.track.your.shot.data.room.response.Player
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
 
 interface AccountManager {
-    val loggedInPlayerListStateFlow: StateFlow<List<Player>>
-    val loggedInDeclaredShotListStateFlow: StateFlow<List<DeclaredShot>>
     val hasLoggedInSuccessfulFlow: Flow<Boolean>
-    val hasNoPlayersFlow: Flow<Boolean>
 
     fun logout()
     fun checkIfWeNeedToLogoutOnLaunch()
     fun login(email: String, password: String)
     fun deleteAllPendingShotsAndPlayers()
-    fun updateLoggedInDeclaredShotFlow(declaredShots: List<DeclaredShot>)
 }

--- a/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManagerImplTest.kt
+++ b/helper/account/src/test/java/com/nicholas/rutherford/track/your/shot/helper/account/AccountManagerImplTest.kt
@@ -313,11 +313,6 @@ class AccountManagerImplTest {
 
             accountManagerImpl.updateActiveUserFromLoggedInUser(email = activeUserEntity.email, username = activeUserEntity.username)
 
-            Assertions.assertEquals(
-                accountManagerImpl.loggedInDeclaredShotListStateFlow.value,
-                declaredShotList
-            )
-
             coVerify {
                 activeUserRepository.createActiveUser(
                     activeUser = ActiveUser(
@@ -344,11 +339,6 @@ class AccountManagerImplTest {
             coEvery { readFirebaseUserInfo.getPlayerInfoList() } returns flowOf(playerInfoRealtimeWithKeyResponseList)
 
             accountManagerImpl.updateActiveUserFromLoggedInUser(email = activeUserEntity.email, username = activeUserEntity.username)
-
-            Assertions.assertEquals(
-                accountManagerImpl.loggedInDeclaredShotListStateFlow.value,
-                declaredShotList
-            )
 
             coVerify {
                 activeUserRepository.createActiveUser(
@@ -413,11 +403,6 @@ class AccountManagerImplTest {
             coEvery { readFirebaseUserInfo.getPlayerInfoList() } returns flowOf(playerInfoRealtimeWithKeyResponseList)
 
             accountManagerImpl.collectPlayerInfoList()
-
-            Assertions.assertEquals(
-                accountManagerImpl.loggedInPlayerListStateFlow.value,
-                playerArrayList.toList()
-            )
 
             coVerify { playerRepository.createListOfPlayers(playerList = any()) }
         }


### PR DESCRIPTION
### Trello
https://trello.com/c/7Nd5OpLS/232-removing-collecting-from-flows-from-the-accountmanager 

### Issues
- There isn’t really a need to collect from Flows anymore at least what `AccountMnagaerImpl` gives me when logging in and logging out as far as shot / player data we get back from Firebase Realtime Database. Thats due to the fact that, we have implemented in the pass to call functionality when navigating to given screens vs when the app is loaded on the `NavigationComponent` side of things. So due to that when we login for example and observe Firebase calls to fill in the database, we could just fill in the database like where doing; and then from there call the Room database calls when navigating to the screen by using the `BaseViewModel` `onNavigatedTo` functionality. 

### Proposed Changes
- Remove unnecessary flow collection now done by AccountManager and instead, when navigating to the screen just call the dao data we need to fetch to show to the user. I did keep in the login flow that happens on AccountManager so that after the user has logged in we can collect it and keep the flow observed. There may be a use case where it can be abstracted, but right now it seems like common practice to do so. 

### TO-DO
- UI / UX clean up 
- More code smell clean ups like this one 
- Introduce the ability for users to create there own shots in the app. 

### Additional Info
- Abstracting this over saves about 300+ lines of code which is awesome to see. 

### Screenshots / Videos 
- N/A 