### PR TITLE
nick: Update player list selection to be a bottom sheet that opens when clicking

### DIFF
--- a/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
+++ b/app/src/main/java/com/nicholas/rutherford/track/your/shot/NavigationComponent.kt
@@ -350,8 +350,8 @@ fun NavigationComponent(
                         onToolbarMenuClicked = { playersListViewModel.onToolbarMenuClicked() },
                         updatePlayerListState = { playersListViewModel.updatePlayerListState() },
                         onAddPlayerClicked = { playersListViewModel.onAddPlayerClicked() },
-                        onEditPlayerClicked = { player -> playersListViewModel.onEditPlayerClicked(player = player) },
-                        onDeletePlayerClicked = { player -> playersListViewModel.onDeletePlayerClicked(player = player) }
+                        onPlayerClicked = { player -> playersListViewModel.onPlayerClicked(player = player) },
+                        onSheetItemClicked = { index -> playersListViewModel.onSheetItemClicked(index = index) }
                     )
                 )
             }

--- a/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
+++ b/base-resources/src/main/java/com/nicholas/rutherford/track/your/shot/base/resources/StringsIds.kt
@@ -75,6 +75,7 @@ object StringsIds {
     val firstName = R.string.first_name
     val forgotPassword = R.string.forgot_password
     val editPlayer = R.string.edit_player
+    val editX = R.string.edit_x
     val empty = R.string.empty
     val emptyField = R.string.empty_field
     val emptyFields = R.string.empty_fields

--- a/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/BottomSheetWithOptions.kt
+++ b/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/BottomSheetWithOptions.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
@@ -35,7 +35,7 @@ import com.nicholas.rutherford.track.your.shot.helper.ui.TextStyles
 fun BottomSheetWithOptions(
     sheetState: ModalBottomSheetState = rememberModalBottomSheetState(Hidden),
     sheetInfo: Sheet? = null,
-    onSheetItemClicked: (String) -> Unit = {},
+    onSheetItemClicked: (String, Int) -> Unit = { _, _ -> },
     onCancelItemClicked: () -> Unit = {},
     content: @Composable () -> Unit
 ) {
@@ -56,7 +56,7 @@ fun BottomSheetWithOptions(
 @Composable
 private fun SheetContent(
     sheet: Sheet?,
-    onSheetItemClicked: (String) -> Unit,
+    onSheetItemClicked: (String, Int) -> Unit = { _, _ -> },
     onCancelItemClicked: () -> Unit
 ) {
     sheet?.let {
@@ -66,12 +66,12 @@ private fun SheetContent(
             style = TextStyles.smallBold
         )
         LazyColumn {
-            items(it.values) { value ->
+            itemsIndexed(it.values) { index, value ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 12.dp, horizontal = 20.dp)
-                        .clickable { onSheetItemClicked(value) }
+                        .clickable { onSheetItemClicked(value, index) }
                 ) {
                     Text(
                         text = value,

--- a/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/BottomSheetWithOptions.kt
+++ b/compose/components/src/main/java/com/nicholas/rutherford/track/your/shot/compose/components/BottomSheetWithOptions.kt
@@ -1,0 +1,93 @@
+package com.nicholas.rutherford.track.your.shot.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue.Hidden
+import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.nicholas.rutherford.track.your.shot.AppColors
+import com.nicholas.rutherford.track.your.shot.base.resources.R
+import com.nicholas.rutherford.track.your.shot.data.shared.sheet.Sheet
+import com.nicholas.rutherford.track.your.shot.helper.ui.TextStyles
+
+/**
+ * Basic [ModalBottomSheetLayout] that is reused across the app when displaying sheet with options
+ *
+ * @param sheetState [ModalBottomSheetState] which contains state of the sheet
+ * @param sheetInfo [Sheet] optional param that define data for each sheet option
+ * @param onSheetItemClicked [Unit] that is invoked when user clicks on a [Sheet] defined item
+ * @param onCancelItemClicked [Unit] that is invoked when cancel sheet item is clicked
+ * @param content [Composable] [Unit] that contains the User interface outside of the bottom sheet
+ */
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun BottomSheetWithOptions(
+    sheetState: ModalBottomSheetState = rememberModalBottomSheetState(Hidden),
+    sheetInfo: Sheet? = null,
+    onSheetItemClicked: (String) -> Unit = {},
+    onCancelItemClicked: () -> Unit = {},
+    content: @Composable () -> Unit
+) {
+    ModalBottomSheetLayout(
+        sheetState = sheetState,
+        sheetContent = {
+            SheetContent(
+                sheet = sheetInfo,
+                onSheetItemClicked = onSheetItemClicked,
+                onCancelItemClicked = onCancelItemClicked
+            )
+        }
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun SheetContent(
+    sheet: Sheet?,
+    onSheetItemClicked: (String) -> Unit,
+    onCancelItemClicked: () -> Unit
+) {
+    sheet?.let {
+        Text(
+            text = it.title,
+            modifier = Modifier.padding(vertical = 12.dp, horizontal = 20.dp),
+            style = TextStyles.smallBold
+        )
+        LazyColumn {
+            items(it.values) { value ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 12.dp, horizontal = 20.dp)
+                        .clickable { onSheetItemClicked(value) }
+                ) {
+                    Text(
+                        text = value,
+                        modifier = Modifier.padding(end = 20.dp),
+                        style = TextStyles.body
+                    )
+                }
+            }
+        }
+    }
+    Text(
+        text = stringResource(id = R.string.cancel),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp, horizontal = 20.dp)
+            .clickable { onCancelItemClicked() },
+        style = TextStyles.body.copy(color = AppColors.Red)
+    )
+}

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerParams.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/createeditplayer/CreateEditPlayerParams.kt
@@ -15,6 +15,6 @@ data class CreateEditPlayerParams(
     val onCreatePlayerClicked: (uri: Uri?) -> Unit,
     val permissionNotGrantedForCameraAlert: () -> Unit,
     val onSelectedCreateEditImageOption: (uri: String) -> CreateEditImageOption,
-    val onViewShotClicked: (shotTypoe: Int, shotId: Int) -> Unit,
+    val onViewShotClicked: (shotType: Int, shotId: Int) -> Unit,
     val onViewPendingShotClicked: (shotType: Int, shotId: Int) -> Unit
 )

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListScreen.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListScreen.kt
@@ -18,22 +18,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue.Hidden
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,13 +39,17 @@ import com.nicholas.rutherford.track.your.shot.AppColors
 import com.nicholas.rutherford.track.your.shot.base.resources.DrawablesIds
 import com.nicholas.rutherford.track.your.shot.base.resources.R
 import com.nicholas.rutherford.track.your.shot.base.resources.StringsIds
+import com.nicholas.rutherford.track.your.shot.compose.components.BottomSheetWithOptions
 import com.nicholas.rutherford.track.your.shot.compose.components.Content
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
 import com.nicholas.rutherford.track.your.shot.data.room.response.PlayerPositions
 import com.nicholas.rutherford.track.your.shot.data.room.response.fullName
 import com.nicholas.rutherford.track.your.shot.data.shared.appbar.AppBar
+import com.nicholas.rutherford.track.your.shot.data.shared.sheet.Sheet
 import com.nicholas.rutherford.track.your.shot.helper.extensions.toPlayerPositionAbvId
 import com.nicholas.rutherford.track.your.shot.helper.ui.TextStyles
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @Composable
 fun PlayersListScreen(playerListScreenParams: PlayersListScreenParams) {
@@ -63,15 +58,7 @@ fun PlayersListScreen(playerListScreenParams: PlayersListScreenParams) {
     Content(
         ui = {
             if (!isPlayerListEmpty) {
-                LazyColumn {
-                    items(playerListScreenParams.state.playerList) { player ->
-                        PlayerItem(
-                            player = player,
-                            onEditPlayerClicked = playerListScreenParams.onEditPlayerClicked,
-                            onDeletePlayerClicked = playerListScreenParams.onDeletePlayerClicked
-                        )
-                    }
-                }
+                PlayerList(playerListScreenParams = playerListScreenParams)
             } else {
                 AddNewPlayerEmptyState()
             }
@@ -89,25 +76,48 @@ fun PlayersListScreen(playerListScreenParams: PlayersListScreenParams) {
     )
 }
 
-//@OptIn(ExperimentalMaterialApi::class)
-//@Composable
-//private fun PlayerList(
-//    player: Player,
-//    onEditPlayerClicked: (player: Player) -> Unit,
-//    onDeletePlayerClicked: (player: Player) -> Unit
-//) {
-//    val bottomState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
-//
-//    ModalBottomSheetLayout(
-//        sheetState = bottomState
-//    )
-//}
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun PlayerList(playerListScreenParams: PlayersListScreenParams) {
+    val sheetState = rememberModalBottomSheetState(Hidden)
+    val scope = rememberCoroutineScope()
 
+    BottomSheetWithOptions(
+        sheetState = sheetState,
+        sheetInfo = Sheet(
+            title = stringResource(id = StringsIds.chooseOption),
+            values = listOf(
+                stringResource(id = R.string.edit_x, playerListScreenParams.state.selectedPlayer.fullName()),
+                stringResource(id = R.string.delete_x, playerListScreenParams.state.selectedPlayer.fullName())
+            )
+        ),
+        onSheetItemClicked = { _, index ->
+            scope.launch { sheetState.hide() }
+            playerListScreenParams.onSheetItemClicked.invoke(index)
+        },
+        onCancelItemClicked = { scope.launch { sheetState.hide() } },
+        content = {
+            LazyColumn {
+                items(playerListScreenParams.state.playerList) { player ->
+                    PlayerItem(
+                        player = player,
+                        onPlayerClicked = playerListScreenParams.onPlayerClicked,
+                        sheetState = sheetState,
+                        scope = scope
+                    )
+                }
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun PlayerItem(
     player: Player,
-    onEditPlayerClicked: (player: Player) -> Unit,
-    onDeletePlayerClicked: (player: Player) -> Unit
+    onPlayerClicked: (player: Player) -> Unit,
+    sheetState: ModalBottomSheetState = rememberModalBottomSheetState(Hidden),
+    scope: CoroutineScope
 ) {
     val imagePainter = if (!player.imageUrl.isNullOrEmpty()) {
         rememberAsyncImagePainter(model = player.imageUrl)
@@ -115,21 +125,22 @@ private fun PlayerItem(
         painterResource(id = DrawablesIds.launcherRound)
     }
 
-    var expanded by remember { mutableStateOf(false) }
-
     Card(
         modifier = Modifier
             .background(AppColors.White)
             .fillMaxWidth()
-            .padding(16.dp),
+            .padding(16.dp)
+            .clickable {
+                scope.launch { sheetState.show() }
+                onPlayerClicked.invoke(player)
+            },
         elevation = 2.dp
     ) {
         Column {
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(8.dp)
-                    .clickable { expanded = true },
+                    .padding(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Image(
@@ -155,42 +166,6 @@ private fun PlayerItem(
                         style = TextStyles.bodyBold,
                         textAlign = TextAlign.Start
                     )
-                }
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                Box {
-                    IconButton(
-                        onClick = { expanded = true }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.MoreVert,
-                            contentDescription = ""
-                        )
-                    }
-
-                    DropdownMenu(
-                        expanded = expanded,
-                        onDismissRequest = { expanded = false }
-                    ) {
-                        DropdownMenuItem(onClick = {
-                            expanded = false
-                            onEditPlayerClicked.invoke(player)
-                        }) {
-                            Text(
-                                text = stringResource(id = R.string.edit_x, player.fullName())
-                            )
-                        }
-
-                        DropdownMenuItem(onClick = {
-                            expanded = false
-                            onDeletePlayerClicked.invoke(player)
-                        }) {
-                            Text(
-                                text = stringResource(id = R.string.delete_x, player.fullName())
-                            )
-                        }
-                    }
                 }
             }
 
@@ -255,8 +230,8 @@ private fun PlayersListScreenWithItemsPreview() {
             onToolbarMenuClicked = {},
             updatePlayerListState = {},
             onAddPlayerClicked = {},
-            onEditPlayerClicked = {},
-            onDeletePlayerClicked = {}
+            onPlayerClicked = {},
+            onSheetItemClicked = {}
         )
     )
 }
@@ -270,8 +245,8 @@ fun PlayerListScreenEmptyStatePreview() {
             onToolbarMenuClicked = {},
             updatePlayerListState = {},
             onAddPlayerClicked = {},
-            onEditPlayerClicked = {},
-            onDeletePlayerClicked = {}
+            onPlayerClicked = {},
+            onSheetItemClicked = {}
         )
     )
 }

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListScreen.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListScreen.kt
@@ -20,11 +20,15 @@ import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -85,8 +89,22 @@ fun PlayersListScreen(playerListScreenParams: PlayersListScreenParams) {
     )
 }
 
+//@OptIn(ExperimentalMaterialApi::class)
+//@Composable
+//private fun PlayerList(
+//    player: Player,
+//    onEditPlayerClicked: (player: Player) -> Unit,
+//    onDeletePlayerClicked: (player: Player) -> Unit
+//) {
+//    val bottomState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
+//
+//    ModalBottomSheetLayout(
+//        sheetState = bottomState
+//    )
+//}
+
 @Composable
-fun PlayerItem(
+private fun PlayerItem(
     player: Player,
     onEditPlayerClicked: (player: Player) -> Unit,
     onDeletePlayerClicked: (player: Player) -> Unit
@@ -182,7 +200,7 @@ fun PlayerItem(
 }
 
 @Composable
-fun AddNewPlayerEmptyState() {
+private fun AddNewPlayerEmptyState() {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -219,7 +237,7 @@ fun AddNewPlayerEmptyState() {
 
 @Composable
 @Preview
-fun PlayersListScreenWithItemsPreview() {
+private fun PlayersListScreenWithItemsPreview() {
     PlayersListScreen(
         playerListScreenParams = PlayersListScreenParams(
             state = PlayersListState(

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListScreenParams.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListScreenParams.kt
@@ -7,6 +7,6 @@ data class PlayersListScreenParams(
     val onToolbarMenuClicked: () -> Unit,
     val updatePlayerListState: () -> Unit,
     val onAddPlayerClicked: () -> Unit,
-    val onEditPlayerClicked: (player: Player) -> Unit,
-    val onDeletePlayerClicked: (player: Player) -> Unit
+    val onPlayerClicked: (player: Player) -> Unit,
+    val onSheetItemClicked: (index: Int) -> Unit
 )

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListState.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListState.kt
@@ -1,7 +1,16 @@
 package com.nicholas.rutherford.track.your.shot.feature.players.playerlist
 
 import com.nicholas.rutherford.track.your.shot.data.room.response.Player
+import com.nicholas.rutherford.track.your.shot.data.room.response.PlayerPositions
 
 data class PlayersListState(
-    val playerList: List<Player> = emptyList()
+    val playerList: List<Player> = emptyList(),
+    val selectedPlayer: Player = Player(
+        firstName = "",
+        lastName = "",
+        position = PlayerPositions.None,
+        firebaseKey = "",
+        imageUrl = "",
+        shotsLoggedList = emptyList()
+    )
 )

--- a/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListViewModel.kt
+++ b/feature/players/src/main/java/com/nicholas/rutherford/track/your/shot/feature/players/playerlist/PlayersListViewModel.kt
@@ -18,9 +18,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 const val DELETE_PLAYER_DELAY_IN_MILLIS = 2000L
+const val EDIT_PLAYER_OPTION_INDEX = 0
 
 class PlayersListViewModel(
     private val application: Application,
@@ -139,9 +141,23 @@ class PlayersListViewModel(
         }
     }
 
-    fun onEditPlayerClicked(player: Player) = navigation.navigateToCreateEditPlayer(firstName = player.firstName, lastName = player.lastName)
+    fun onPlayerClicked(player: Player) {
+        playerListMutableStateFlow.update { it.copy(selectedPlayer = player) }
+    }
 
-    fun onDeletePlayerClicked(player: Player) = navigation.alert(alert = deletePlayerAlert(player = player))
+    fun onSheetItemClicked(index: Int) {
+        val player = playerListMutableStateFlow.value.selectedPlayer
+
+        if (index == EDIT_PLAYER_OPTION_INDEX) {
+            onEditPlayerClicked(player = player)
+        } else {
+            onDeletePlayerClicked(player = player)
+        }
+    }
+
+    internal fun onEditPlayerClicked(player: Player) = navigation.navigateToCreateEditPlayer(firstName = player.firstName, lastName = player.lastName)
+
+    internal fun onDeletePlayerClicked(player: Player) = navigation.alert(alert = deletePlayerAlert(player = player))
 
     private fun deletePlayerAlert(player: Player): Alert {
         return Alert(

--- a/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
+++ b/feature/players/src/test/java/com/nicholas/rutherford/track/your/shot/players/playerlist/PlayersListViewModelTest.kt
@@ -9,6 +9,8 @@ import com.nicholas.rutherford.track.your.shot.data.room.response.PlayerPosition
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.Alert
 import com.nicholas.rutherford.track.your.shot.data.shared.alert.AlertConfirmAndDismissButton
 import com.nicholas.rutherford.track.your.shot.data.test.room.TestPlayer
+import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.DELETE_PLAYER_DELAY_IN_MILLIS
+import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.EDIT_PLAYER_OPTION_INDEX
 import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.PlayersListNavigation
 import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.PlayersListState
 import com.nicholas.rutherford.track.your.shot.feature.players.playerlist.PlayersListViewModel
@@ -25,6 +27,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
@@ -71,6 +74,12 @@ class PlayersListViewModelTest {
             playerRepository = playerRepository,
             pendingPlayerRepository = pendingPlayerRepository
         )
+    }
+
+    @Test
+    fun `constants for player list`() {
+        Assertions.assertEquals(DELETE_PLAYER_DELAY_IN_MILLIS, 2000L)
+        Assertions.assertEquals(EDIT_PLAYER_OPTION_INDEX, 0)
     }
 
     @Test
@@ -393,6 +402,34 @@ class PlayersListViewModelTest {
 
             coVerify { playerRepository.deletePlayerByName(player.firstName, player.lastName) }
             verify { navigation.disableProgress() }
+        }
+    }
+
+    @Test
+    fun `on player clicked should update state`() {
+        val player = TestPlayer().create()
+
+        playersListViewModel.onPlayerClicked(player = player)
+
+        val result = playersListViewModel.playerListMutableStateFlow.value
+
+        Assertions.assertEquals(result, PlayersListState(selectedPlayer = player))
+    }
+
+    @Nested
+    inner class OnSheetItemClicked {
+
+        @Test
+        fun `when index passed in is set to 0 should call on edit player clicked`() {
+            val index = 0
+            val player = TestPlayer().create()
+
+            playersListViewModel.playerListMutableStateFlow.update { it.copy(selectedPlayer = player) }
+
+            playersListViewModel.onSheetItemClicked(index = index)
+
+            verify(exactly = 1) { playersListViewModel.onEditPlayerClicked(player = player) }
+            verify(exactly = 0) { playersListViewModel.onDeletePlayerClicked(player = player) }
         }
     }
 


### PR DESCRIPTION
### Trello
https://trello.com/c/1zcZ3A1q/234-update-player-list-selection-to-be-a-bottom-sheet-that-opens-when-clicking

### Issues
- For the players list section we had the user click into an action image to the right of the row. When clicking on it they will be presented with the ability to delete / edit a player. This workflow was happening through a `DropdownMenu` which makes sense for this workflow but not this one. In the future the user would be able to do more then just edit / delete there player, so it makes sense to introduce this as a bottom sheet for more functional action items in the future. 
- The bottom sheet in question was also being used in the create / edit player workflow when selecting an image. Since its used more then once it makes sense to combine ui workflows into one components so we don't the same work twice. 

### Proposed Changes
- Remove `DropDownMenu` from player list and replace it with a `BottomSheet`. 
- Make the `BottomSheet` a reusable component since the UI is ideally the same across these selected options across the app. 

### TO-DO
- NA 

### Additional Info
- I realized that alot of my libraries are not up to date at all and they should be, so I will be creating a backlog task to go through libraries and create an update strategy. 

### Screenshots / Videos 
![Screenshot_20250126_091459](https://github.com/user-attachments/assets/34977d67-1470-40fb-a7b3-26a249fd54ed)
